### PR TITLE
Refactor: Improve UI for Restaurant, RoomKey, and Home pages

### DIFF
--- a/lib/fragments/home.dart
+++ b/lib/fragments/home.dart
@@ -91,10 +91,8 @@ class _NewsFeedCardState extends State<NewsFeedCard> {
     // Please ensure it is active and has requests remaining on NewsAPI.org dashboard.
     const String newsApiKey = '060f8eb17f9345b59475d62a5fcac3db'; // Use your actual key here
 
-    // --- MODIFIED: Changed country from 'gb' to 'us' for testing ---
-    // NewsAPI.org's free tier often has more "top headlines" for the US.
-    // You can try 'gb' again or other countries once you confirm it works with 'us'.
-    final Uri uri = Uri.parse('https://newsapi.org/v2/top-headlines?sources=bbc-news&pageSize=10&apiKey=$newsApiKey'); // Added pageSize=10
+    // You can try 'gb' again or other countries/sources once you confirm it works.
+    final Uri uri = Uri.parse('https://newsapi.org/v2/top-headlines?sources=bbc-news&pageSize=10&apiKey=$newsApiKey'); // Using bbc-news source
 
     // Check if API key is empty or still the placeholder
     if (newsApiKey == 'YOUR_ACTUAL_NEWS_API_KEY_HERE' || newsApiKey.isEmpty) {
@@ -1573,6 +1571,7 @@ class _NativeWelcomePageState extends State<NativeWelcomePage> {
                     child: ReorderableListView.builder(
                       shrinkWrap: true, // Ensures it takes up only needed vertical space
                       physics: const NeverScrollableScrollPhysics(), // Handled by CustomScrollView
+                      buildDefaultDragHandles: false, // MODIFIED: Disable default drag handles
                       itemCount: _userWidgetOrder.length,
                       onReorder: (int oldIndex, int newIndex) {
                         setState(() {
@@ -1627,22 +1626,28 @@ class _NativeWelcomePageState extends State<NativeWelcomePage> {
                             ),
                           );
 
-                          // Enable dragging for reordering only in edit mode
+                          // Only enable dragging and show handle in edit mode
                           if (_isInEditMode) {
                             return ReorderableDelayedDragStartListener(
                               key: ValueKey(widgetId), // Unique key for ReorderableListView
                               index: index,
-                              child: itemContent,
+                              // MODIFIED: Wrap itemContent with a Row and add a drag handle icon
+                              child: Row(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Expanded(child: itemContent),
+                                  // Drag handle
+                                  Padding(
+                                    padding: const EdgeInsets.only(top: 8.0, left: 8.0),
+                                    child: Icon(Icons.drag_handle_rounded, color: theme.colorScheme.onSurfaceVariant.withOpacity(0.5)),
+                                  ),
+                                ],
+                              ),
                             );
                           } else {
-                            // Enable long press to enter edit mode
-                            return GestureDetector(
-                              key: ValueKey(widgetId), // Unique key for widget identity
-                              onLongPress: () {
-                                setState(() {
-                                  _isInEditMode = true;
-                                });
-                              },
+                            // When not in edit mode, just display the content without reordering
+                            return SizedBox( // Wrap in SizedBox to provide a key for ListView
+                              key: ValueKey(widgetId),
                               child: itemContent,
                             );
                           }
@@ -1675,9 +1680,28 @@ class _NativeWelcomePageState extends State<NativeWelcomePage> {
                   ),
                 ),
               ),
-            // Add some padding at the bottom, especially when in edit mode
+            // NEW: Button to toggle edit mode, always visible at the bottom
             SliverToBoxAdapter(
-              child: SizedBox(height: _isInEditMode ? 24.0 : 0.0),
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: _contentMaxWidth),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
+                    child: FilledButton.tonal(
+                      onPressed: () {
+                        setState(() {
+                          _isInEditMode = !_isInEditMode; // Toggle edit mode
+                        });
+                      },
+                      style: FilledButton.styleFrom(
+                        minimumSize: const Size.fromHeight(50),
+                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12.0)),
+                      ),
+                      child: Text(_isInEditMode ? 'Exit Edit Mode' : 'Edit Widgets'),
+                    ),
+                  ),
+                ),
+              ),
             ),
           ],
         ),

--- a/lib/fragments/restaurant.dart
+++ b/lib/fragments/restaurant.dart
@@ -1,8 +1,8 @@
+// fragments/restaurant.dart
+
 import 'package:flutter/material.dart';
 
 // Import the newly created HiCafePage
-// Assuming hicafe_page.dart is in a subdirectory 'restaurant' under 'fragments'
-// Adjust the path if your file structure is different.
 import 'restaurant/hicafe_page.dart';
 import 'restaurant/breakfast_page.dart';
 import 'restaurant/cafefiesta_page.dart';
@@ -14,54 +14,56 @@ class RestaurantPage extends StatelessWidget {
   // Define a max width for desktop-like content presentation
   static const double _contentMaxWidth = 768.0;
 
-  // Helper function to create styled list items similar to the buttons
+  // Helper function to create styled list items for restaurant options
   Widget _buildRestaurantOption({
     required BuildContext context,
     required IconData icon,
     required String label,
     required VoidCallback onTap,
-    bool isFirst = false,
-    bool isLast = false,
   }) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
-    // Define border radius based on position
-    BorderRadius borderRadius;
-    if (isFirst && isLast) { // Only one item
-      borderRadius = BorderRadius.circular(16.0);
-    } else if (isFirst) {
-      borderRadius = const BorderRadius.vertical(top: Radius.circular(16.0), bottom: Radius.circular(5.0));
-    } else if (isLast) {
-      borderRadius = const BorderRadius.vertical(top: Radius.circular(5.0), bottom: Radius.circular(16.0));
-    } else {
-      borderRadius = BorderRadius.circular(5.0);
-    }
+    // Apply a consistent border radius to all cards
+    BorderRadius borderRadius = BorderRadius.circular(16.0);
 
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 1.0), // Small gap like settings items
-      child: Material(
-        color: colorScheme.secondaryContainer, // Using a card-like color
-        shape: RoundedRectangleBorder(borderRadius: borderRadius),
-        clipBehavior: Clip.antiAlias,
+    return Container(
+      // No external margin here, spacing is handled by SizedBox in the parent Column
+      decoration: BoxDecoration(
+        color: colorScheme.secondaryContainer, // Background color for the item
+        borderRadius: borderRadius,
+        boxShadow: [ // Softer shadow for depth
+          BoxShadow(
+            color: Colors.black.withOpacity(0.08), // Slightly more visible than 0.05, but still subtle
+            spreadRadius: 1,
+            blurRadius: 6, // Slightly more blur
+            offset: const Offset(0, 3), // More pronounced vertical offset
+          ),
+        ],
+      ),
+      child: Material( // Material widget for InkWell splash effect
+        color: Colors.transparent, // Make Material transparent to show Container's decoration
         child: InkWell(
           onTap: onTap,
+          borderRadius: borderRadius, // Match container's border radius
           child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 18.0),
+            padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 20.0), // Generous internal padding
             child: Row(
               children: [
-                Icon(icon, color: colorScheme.onSecondaryContainer, size: 28), // Adjusted for secondaryContainer
+                Icon(icon, color: colorScheme.onSecondaryContainer, size: 32), // Clear icon size
                 const SizedBox(width: 16.0),
                 Expanded(
                   child: Text(
                     label,
-                    style: theme.textTheme.titleMedium?.copyWith(
-                      color: colorScheme.onSecondaryContainer, // Adjusted for secondaryContainer
-                      fontWeight: FontWeight.w500,
+                    style: theme.textTheme.titleLarge?.copyWith( // Prominent and bold text
+                      color: colorScheme.onSecondaryContainer,
+                      fontWeight: FontWeight.w600,
                     ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
-                Icon(Icons.chevron_right_rounded, color: colorScheme.onSecondaryContainer.withOpacity(0.7)), // Adjusted for secondaryContainer
+                Icon(Icons.chevron_right_rounded, color: colorScheme.onSecondaryContainer.withOpacity(0.7)), // Navigation icon
               ],
             ),
           ),
@@ -110,7 +112,7 @@ class RestaurantPage extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  // Header Section - styled like welcome page
+                  // Header Section - styled like welcome page (Kept as requested)
                   Padding(
                     padding: const EdgeInsets.symmetric(vertical: 24.0),
                     child: Column(
@@ -145,27 +147,26 @@ class RestaurantPage extends StatelessWidget {
                       ],
                     ),
                   ),
-                  // const SizedBox(height: 20.0), // Original spacing before action items, adjust as needed
+                  const SizedBox(height: 12.0), // Adjusted spacing before list items
 
-                  // Action Items
-                  // The Container around this Column of options is not strictly needed
-                  // if there's no specific background or decoration for the group itself.
-                  // The _buildRestaurantOption handles its own background.
+                  // Action Items - Now a refined list
                   Column(
                     children: List.generate(restaurantActions.length, (index) {
                       final action = restaurantActions[index];
-                      return _buildRestaurantOption(
-                        context: context,
-                        icon: action['icon'] as IconData,
-                        label: action['label'] as String,
-                        onTap: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(builder: (_) => action['page'] as Widget),
-                          );
-                        },
-                        isFirst: index == 0,
-                        isLast: index == restaurantActions.length - 1,
+                      // Add SizedBox for vertical spacing BETWEEN items
+                      return Padding(
+                        padding: EdgeInsets.only(bottom: index == restaurantActions.length - 1 ? 0.0 : 12.0), // Space after each, but not the last
+                        child: _buildRestaurantOption(
+                          context: context,
+                          icon: action['icon'] as IconData,
+                          label: action['label'] as String,
+                          onTap: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(builder: (_) => action['page'] as Widget),
+                            );
+                          },
+                        ),
                       );
                     }),
                   ),

--- a/lib/fragments/roomkey.dart
+++ b/lib/fragments/roomkey.dart
@@ -1,16 +1,18 @@
+// fragments/roomkey.dart
+
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart'; // Import for date formatting
 
-class RoomKeyPage extends StatefulWidget { // Changed to StatefulWidget
+class RoomKeyPage extends StatefulWidget {
   const RoomKeyPage({super.key});
 
   @override
   State<RoomKeyPage> createState() => _RoomKeyPageState();
 }
 
-class _RoomKeyPageState extends State<RoomKeyPage> { // New State class
+class _RoomKeyPageState extends State<RoomKeyPage> {
   // Define a max width for desktop-like content presentation
-  static const double _contentMaxWidth = 400.0; // Adjusted for a card-like appearance
+  static const double _contentMaxWidth = 450.0; // Slightly increased for better card proportion
   final String _nfcGifUrl = 'https://cdn.dribbble.com/users/1489841/screenshots/11131159/nfc.gif';
 
   // Placeholder data - in a real app, this would come from user session, booking details, etc.
@@ -30,14 +32,12 @@ class _RoomKeyPageState extends State<RoomKeyPage> { // New State class
 
   void _updateDates() {
     final now = DateTime.now();
-    final dateFormat = DateFormat('MMM d, yyyy'); // Example: May 26, 2025
+    // Example: May 26, 2025 (e.g., Mon, Jun 10)
+    final dateFormat = DateFormat('EEE, MMM d, y');
 
     _checkInDate = dateFormat.format(now);
     _checkOutDate = dateFormat.format(now.add(const Duration(days: 2))); // Check-out 2 days from now
-
-    // No need to call setState here as initState is called before the first build
   }
-
 
   @override
   Widget build(BuildContext context) {
@@ -54,7 +54,7 @@ class _RoomKeyPageState extends State<RoomKeyPage> { // New State class
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                // Header Section
+                // Header Section - Kept as requested
                 Padding(
                   padding: const EdgeInsets.only(bottom: 24.0, top: 8.0),
                   child: Row(
@@ -67,7 +67,7 @@ class _RoomKeyPageState extends State<RoomKeyPage> { // New State class
                       ),
                       const SizedBox(width: 12),
                       Text(
-                        'Room Key', // Changed title slightly
+                        'Room Key', // Title remains the same
                         style: theme.textTheme.displaySmall?.copyWith(
                           fontWeight: FontWeight.bold,
                           color: colorScheme.primary,
@@ -80,10 +80,10 @@ class _RoomKeyPageState extends State<RoomKeyPage> { // New State class
 
                 // Digital Key Card
                 Card(
-                  elevation: 4.0, // Give it a slight lift
+                  elevation: 8.0, // Increased elevation for a more premium feel
                   color: colorScheme.primaryContainer,
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20.0)), // More rounded
-                  clipBehavior: Clip.antiAlias,
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24.0)), // More rounded corners
+                  clipBehavior: Clip.antiAlias, // Ensures content respects rounded corners
                   child: InkWell( // Make the whole card tappable for "unlock" action
                     onTap: () {
                       // TODO: Implement NFC tap/unlock functionality
@@ -91,9 +91,9 @@ class _RoomKeyPageState extends State<RoomKeyPage> { // New State class
                         const SnackBar(content: Text('Room key tapped! (NFC action pending)')),
                       );
                     },
-                    borderRadius: BorderRadius.circular(20.0),
+                    borderRadius: BorderRadius.circular(24.0), // Match card border radius
                     child: Padding(
-                      padding: const EdgeInsets.all(20.0),
+                      padding: const EdgeInsets.all(28.0), // Increased padding for spaciousness
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
@@ -102,44 +102,53 @@ class _RoomKeyPageState extends State<RoomKeyPage> { // New State class
                             _hotelName,
                             style: theme.textTheme.titleSmall?.copyWith(
                               color: colorScheme.onPrimaryContainer.withOpacity(0.8),
+                              fontWeight: FontWeight.w600,
                             ),
                           ),
-                          const SizedBox(height: 16.0),
+                          const SizedBox(height: 24.0), // More vertical space
+
+                          // Room Number - Made more prominent
                           Text(
                             'ROOM',
-                            style: theme.textTheme.labelMedium?.copyWith(
+                            style: theme.textTheme.labelLarge?.copyWith(
                               color: colorScheme.onPrimaryContainer.withOpacity(0.7),
-                              letterSpacing: 1.5,
+                              letterSpacing: 2.0, // Increased letter spacing
+                              fontWeight: FontWeight.bold,
                             ),
                           ),
                           Text(
                             _roomNumber,
-                            style: theme.textTheme.displayMedium?.copyWith(
+                            style: theme.textTheme.displayLarge?.copyWith( // Larger font size
                               color: colorScheme.onPrimaryContainer,
-                              fontWeight: FontWeight.bold,
+                              fontWeight: FontWeight.w900, // Extra bold
                             ),
                           ),
-                          const SizedBox(height: 20.0),
+                          const SizedBox(height: 32.0), // More vertical space
+
+                          // Guest & Dates Section
                           Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            crossAxisAlignment: CrossAxisAlignment.start, // Align top of children
                             children: [
-                              Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    'GUEST',
-                                    style: theme.textTheme.labelSmall?.copyWith(color: colorScheme.onPrimaryContainer.withOpacity(0.7)),
-                                  ),
-                                  Text(
-                                    _guestName,
-                                    style: theme.textTheme.bodyLarge?.copyWith(color: colorScheme.onPrimaryContainer, fontWeight: FontWeight.w500),
-                                  ),
-                                ],
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      'GUEST',
+                                      style: theme.textTheme.labelSmall?.copyWith(color: colorScheme.onPrimaryContainer.withOpacity(0.7), letterSpacing: 1.0),
+                                    ),
+                                    Text(
+                                      _guestName,
+                                      style: theme.textTheme.titleMedium?.copyWith(color: colorScheme.onPrimaryContainer, fontWeight: FontWeight.w600),
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ],
+                                ),
                               ),
-                              // You can add another piece of info here if needed
                             ],
                           ),
-                          const SizedBox(height: 12.0),
+                          const SizedBox(height: 16.0), // Space between guest and dates
                           Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
@@ -148,11 +157,11 @@ class _RoomKeyPageState extends State<RoomKeyPage> { // New State class
                                 children: [
                                   Text(
                                     'CHECK-IN',
-                                    style: theme.textTheme.labelSmall?.copyWith(color: colorScheme.onPrimaryContainer.withOpacity(0.7)),
+                                    style: theme.textTheme.labelSmall?.copyWith(color: colorScheme.onPrimaryContainer.withOpacity(0.7), letterSpacing: 1.0),
                                   ),
                                   Text(
                                     _checkInDate, // Using dynamic date
-                                    style: theme.textTheme.bodyMedium?.copyWith(color: colorScheme.onPrimaryContainer),
+                                    style: theme.textTheme.titleSmall?.copyWith(color: colorScheme.onPrimaryContainer),
                                   ),
                                 ],
                               ),
@@ -161,38 +170,40 @@ class _RoomKeyPageState extends State<RoomKeyPage> { // New State class
                                 children: [
                                   Text(
                                     'CHECK-OUT',
-                                    style: theme.textTheme.labelSmall?.copyWith(color: colorScheme.onPrimaryContainer.withOpacity(0.7)),
+                                    style: theme.textTheme.labelSmall?.copyWith(color: colorScheme.onPrimaryContainer.withOpacity(0.7), letterSpacing: 1.0),
                                   ),
                                   Text(
                                     _checkOutDate, // Using dynamic date
-                                    style: theme.textTheme.bodyMedium?.copyWith(color: colorScheme.onPrimaryContainer),
+                                    style: theme.textTheme.titleSmall?.copyWith(color: colorScheme.onPrimaryContainer),
                                   ),
                                 ],
                               ),
                             ],
                           ),
-                          const SizedBox(height: 24.0),
-                          Center( // Center the NFC interaction area
+                          const SizedBox(height: 32.0), // More space before NFC area
+
+                          // NFC Interaction Area
+                          Center(
                             child: Column(
                               children: [
                                 Image.network(
                                   _nfcGifUrl,
                                   fit: BoxFit.contain,
-                                  height: 100, // Adjusted GIF size
+                                  height: 120, // Increased GIF size
                                   loadingBuilder: (context, child, loadingProgress) {
                                     if (loadingProgress == null) return child;
-                                    return const SizedBox(height: 100, child: Center(child: CircularProgressIndicator()));
+                                    return SizedBox(height: 120, child: Center(child: CircularProgressIndicator(color: colorScheme.onPrimaryContainer.withOpacity(0.5))));
                                   },
                                   errorBuilder: (context, error, stackTrace) {
-                                    return Icon(Icons.nfc_rounded, size: 80, color: colorScheme.onPrimaryContainer.withOpacity(0.5));
+                                    return Icon(Icons.nfc_rounded, size: 100, color: colorScheme.onPrimaryContainer.withOpacity(0.5));
                                   },
                                 ),
-                                const SizedBox(height: 12.0),
+                                const SizedBox(height: 16.0), // Space between GIF and text
                                 Text(
                                   'Tap phone on door handle to unlock',
-                                  style: theme.textTheme.titleMedium?.copyWith(
+                                  style: theme.textTheme.titleLarge?.copyWith( // Larger, more prominent text
                                     color: colorScheme.onPrimaryContainer,
-                                    fontWeight: FontWeight.w500,
+                                    fontWeight: FontWeight.w600,
                                   ),
                                   textAlign: TextAlign.center,
                                 ),
@@ -204,25 +215,27 @@ class _RoomKeyPageState extends State<RoomKeyPage> { // New State class
                     ),
                   ),
                 ),
-                const SizedBox(height: 20.0),
+                const SizedBox(height: 24.0), // Space before NFC info box
 
-                // NFC Information
+                // NFC Information Box - Styled for clarity
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 10.0),
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 14.0),
                   decoration: BoxDecoration(
-                    color: colorScheme.surfaceContainerHighest, // A slightly different background for this info
-                    borderRadius: BorderRadius.circular(12.0),
+                    color: colorScheme.surfaceContainer, // A distinct background color
+                    borderRadius: BorderRadius.circular(16.0), // Match key card's roundedness
+                    border: Border.all(color: colorScheme.outlineVariant.withOpacity(0.5), width: 1.0), // Subtle border
                   ),
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      Icon(Icons.info_outline_rounded, color: colorScheme.onSurfaceVariant, size: 20),
-                      const SizedBox(width: 8),
+                      Icon(Icons.info_outline_rounded, color: colorScheme.onSurfaceVariant, size: 22),
+                      const SizedBox(width: 10),
                       Expanded(
                         child: Text(
-                          'NFC must be enabled on your device to use this feature.',
+                          'NFC must be enabled on your device to use this feature. Ensure your phone is unlocked.',
                           style: theme.textTheme.bodyMedium?.copyWith(
                             color: colorScheme.onSurfaceVariant,
+                            height: 1.4, // Improve line spacing
                           ),
                           textAlign: TextAlign.center,
                         ),
@@ -230,6 +243,7 @@ class _RoomKeyPageState extends State<RoomKeyPage> { // New State class
                     ],
                   ),
                 ),
+                const SizedBox(height: 24.0), // Final padding at bottom
               ],
             ),
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -203,7 +203,7 @@ class _ResponsiveScaffoldState extends State<ResponsiveScaffold> {
   int _selectedIndex = 0; // Tracks currently selected navigation index
 
   final List<String> _titles = [
-    'Home',
+    'Dashboard',
     'Food',
     'Hotel',
     'Room Key',
@@ -301,7 +301,7 @@ class _ResponsiveScaffoldState extends State<ResponsiveScaffold> {
           : NavigationRailLabelType.none,
       destinations: const [
         NavigationRailDestination(
-            icon: Icon(Icons.home_rounded), label: Text('Home')),
+            icon: Icon(Icons.dashboard_rounded), label: Text('Dashboard')),
         NavigationRailDestination(
             icon: Icon(Icons.restaurant_rounded), label: Text('Food')),
         NavigationRailDestination(
@@ -325,7 +325,7 @@ class _ResponsiveScaffoldState extends State<ResponsiveScaffold> {
         height: 60,
         elevation: 8,
         destinations: const [
-          NavigationDestination(icon: Icon(Icons.home_rounded), label: 'Home'),
+          NavigationDestination(icon: Icon(Icons.dashboard_rounded), label: 'Dashboard'),
           NavigationDestination(icon: Icon(Icons.restaurant_rounded), label: 'Food'),
           NavigationDestination(icon: Icon(Icons.hotel_rounded), label: 'Hotel'),
           NavigationDestination(icon: Icon(Icons.key_rounded), label: 'Room Key'),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 3.2.2+1
+version: 3.2.2+2
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
This commit introduces several UI enhancements across the app:

**Restaurant Page:**
- Updated the restaurant options list items to have a consistent card-like appearance with rounded corners and subtle shadows.
- Increased padding and text size for better readability and a more premium feel.

**Room Key Page:**
- Enhanced the digital key card design with increased elevation, more rounded corners, and spacious padding.
- Made text elements (room number, guest name, dates) more prominent.
- Improved the NFC interaction area with a larger GIF and clearer instructions.
- Styled the NFC information box for better clarity and visual distinction.
- Updated date formatting to include the day of the week.

**Home Page:**
- Changed the NewsAPI source to 'bbc-news'.
- Disabled default drag handles in the reorderable list view.
- Added a visual drag handle icon to items when in edit mode.
- Items are no longer long-press to enter edit mode; an "Edit Widgets" / "Exit Edit Mode" button is now present at the bottom of the widget list.

**Main:**
- Changed the "Home" navigation label and title to "Dashboard".
- Updated navigation icons to use `dashboard_rounded` for the first tab.

**General:**
- Incremented build number.