### PR TITLE
Refactor: Introduce QuickActionsCard and improve home screen customiz…

### DIFF
--- a/lib/widgets/quick_actions_card.dart
+++ b/lib/widgets/quick_actions_card.dart
@@ -1,0 +1,248 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// A model for a single quick action item
+class QuickAction {
+  final String id;
+  final String label;
+  final IconData icon;
+  final int tabIndex;
+
+  const QuickAction({
+    required this.id,
+    required this.label,
+    required this.icon,
+    required this.tabIndex,
+  });
+}
+
+// A list of all possible quick actions you might want to offer.
+// You can add or remove items from this list.
+const List<QuickAction> allAvailableActions = [
+  QuickAction(id: 'food', label: 'Order Food', icon: Icons.restaurant_rounded, tabIndex: 1),
+  QuickAction(id: 'stay', label: 'Book Stay', icon: Icons.hotel_rounded, tabIndex: 2),
+  QuickAction(id: 'roomkey', label: 'View Room Key', icon: Icons.key_rounded, tabIndex: 3),
+];
+
+class QuickActionsCard extends StatefulWidget {
+  final Function(int) onNavigateToTab;
+  const QuickActionsCard({super.key, required this.onNavigateToTab});
+
+  @override
+  State<QuickActionsCard> createState() => _QuickActionsCardState();
+}
+
+class _QuickActionsCardState extends State<QuickActionsCard> {
+  List<QuickAction> _selectedActions = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSelectedActions();
+  }
+
+  // Load the user's saved preferences for which actions to show
+  Future<void> _loadSelectedActions() async {
+    final prefs = await SharedPreferences.getInstance();
+    final List<String>? savedActionIds = prefs.getStringList('selectedQuickActions');
+
+    setState(() {
+      if (savedActionIds == null || savedActionIds.isEmpty) {
+        // If nothing is saved, show the first two actions by default
+        _selectedActions = allAvailableActions.take(2).toList();
+      } else {
+        // Otherwise, load the actions that the user previously selected
+        _selectedActions = allAvailableActions
+            .where((action) => savedActionIds.contains(action.id))
+            .toList();
+      }
+    });
+  }
+
+  // Show a dialog to let the user pick which actions they want to see
+  void _showEditActionsDialog() {
+    final theme = Theme.of(context);
+    final tempSelectedIds = _selectedActions.map((a) => a.id).toList();
+
+    showDialog(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setDialogState) {
+            return AlertDialog(
+              title: const Text('Customize Quick Actions'),
+              content: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: allAvailableActions.map((action) {
+                    final isSelected = tempSelectedIds.contains(action.id);
+                    return CheckboxListTile(
+                      title: Text(action.label),
+                      value: isSelected,
+                      onChanged: (bool? value) {
+                        // UPDATED: Add logic to limit selection to 2
+                        if (value == true && tempSelectedIds.length >= 2) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('You can only select up to 2 actions.'),
+                              duration: Duration(seconds: 2),
+                            ),
+                          );
+                          return; // Prevent selecting a third item
+                        }
+
+                        setDialogState(() {
+                          if (value == true) {
+                            tempSelectedIds.add(action.id);
+                          } else {
+                            tempSelectedIds.remove(action.id);
+                          }
+                        });
+                      },
+                    );
+                  }).toList(),
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Cancel'),
+                ),
+                FilledButton(
+                  onPressed: () async {
+                    final prefs = await SharedPreferences.getInstance();
+                    await prefs.setStringList('selectedQuickActions', tempSelectedIds);
+                    _loadSelectedActions(); // Reload the actions on the card
+                    if (mounted) Navigator.pop(context);
+                  },
+                  child: const Text('Save'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    // The main card container
+    return Card(
+      elevation: 0,
+      color: theme.colorScheme.surfaceVariant.withAlpha(150),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20.0)),
+      child: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Card Header: Title and Edit Button
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'Quick Actions',
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                IconButton(
+                  icon: Icon(Icons.edit_rounded, color: theme.colorScheme.onSurfaceVariant),
+                  onPressed: _showEditActionsDialog,
+                  tooltip: 'Edit Quick Actions',
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            // UPDATED: Use a SizedBox and Row for consistent height
+            SizedBox(
+              height: 110, // This fixed height ensures the card size is consistent
+              child: _buildActionsContent(),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Builds the content area for the actions, showing either the buttons or a placeholder.
+  Widget _buildActionsContent() {
+    if (_selectedActions.isEmpty) {
+      // Show a placeholder if no actions are selected
+      return Center(
+        child: Text(
+          'No actions selected.\nTap the edit icon to add some.',
+          textAlign: TextAlign.center,
+          style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
+        ),
+      );
+    }
+
+    // Use a Row with Expanded children to ensure consistent layout for 1 or 2 items
+    return Row(
+      children: List.generate(2, (index) {
+        if (index < _selectedActions.length) {
+          // If an action exists for this index, build the button
+          final action = _selectedActions[index];
+          return Expanded(
+            child: _buildQuickActionCard(
+              context: context,
+              icon: action.icon,
+              label: action.label,
+              onTap: () => widget.onNavigateToTab(action.tabIndex),
+            ),
+          );
+        }
+        // Return an empty container to act as a spacer if there's only one action
+        return Expanded(child: Container());
+      })
+          .expand((widget) => [widget, const SizedBox(width: 16)]) // Add spacing between items
+          .toList()
+        ..removeLast(), // Remove the last SizedBox
+    );
+  }
+
+  // Builds the individual action button
+  Widget _buildQuickActionCard({
+    required BuildContext context,
+    required IconData icon,
+    required String label,
+    required VoidCallback onTap,
+  }) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
+      color: colorScheme.primaryContainer,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(16.0),
+        child: Padding(
+          padding: const EdgeInsets.all(12.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, size: 32, color: colorScheme.onPrimaryContainer),
+              const SizedBox(height: 12),
+              Text(
+                label,
+                style: theme.textTheme.titleSmall?.copyWith(
+                  color: colorScheme.onPrimaryContainer,
+                  fontWeight: FontWeight.w600,
+                ),
+                textAlign: TextAlign.center,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -560,6 +560,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  reorderable_grid_view:
+    dependency: "direct main"
+    description:
+      name: reorderable_grid_view
+      sha256: e36c6229a97105a10c79e15ab4b9b14ee9f6c488574ff2be9e858c82af47cda6
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.8"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 3.2.5+4
+version: 3.2.6+5
 
 environment:
   sdk: ^3.7.2
@@ -49,6 +49,7 @@ dependencies:
   geolocator: ^14.0.0
   http: ^1.4.0
   package_info_plus: ^8.3.0
+  reorderable_grid_view: ^2.2.8
 
 dev_dependencies:
   flutter_launcher_icons: ^0.14.3


### PR DESCRIPTION
…ation

This commit introduces a new `QuickActionsCard` widget, allowing users to customize and display up to two quick action buttons.

Key changes:

- **New `QuickActionsCard` Widget:**
    - Provides a dedicated card for quick actions like "Order Food" or "Book Stay".
    - Users can edit and select up to two actions to display.
    - Selections are saved using `shared_preferences`.
    - Handles cases with 0, 1, or 2 selected actions gracefully.
- **Home Screen (`home.dart`) Refactor:**
    - Replaced the inline quick actions implementation with the new `QuickActionsCard`.
    - Simplified widget management by introducing a `DashboardWidgetModel` to store widget ID, display name, and builder function. This removes the need for switch statements when handling widget display and metadata.
    - Improved layout consistency for the "Quick Actions" content area using a fixed-height `SizedBox` and `Row`.
    - Enhanced the "Add Widget" dialog to use the display name from `DashboardWidgetModel`.
    - Improved the visual appearance of the "Remove Widget" button in edit mode with an `AnimatedOpacity` effect.
    - Added an empty state UI when no dashboard widgets are present.
    - Implemented reordering for the two-column layout using `reorderable_grid_view`.
    - Default widget order now loads from `_availableWidgets.keys` if no saved order is found.
    - Minor UI tweaks and styling improvements.
- **Dependencies:**
    - Added `reorderable_grid_view: ^2.2.8` to `pubspec.yaml` for the two-column reordering feature.