### PR TITLE
Refactor: Replace YoutubePlayer with InAppWebView for YouTubeCard

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -254,14 +254,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
-  flutter_staggered_grid_view:
-    dependency: "direct main"
-    description:
-      name: flutter_staggered_grid_view
-      sha256: "19e7abb550c96fbfeb546b23f3ff356ee7c59a019a651f8f102a4ba9b7349395"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -901,14 +893,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
-  youtube_player_flutter:
-    dependency: "direct main"
-    description:
-      name: youtube_player_flutter
-      sha256: "924a4099b052119a42bbd9491be8891ab3c2e05074f3649ce73b596f3f440f19"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.1.2"
 sdks:
   dart: ">=3.8.0 <4.0.0"
   flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 3.3.3+8
+version: 3.3.4+9
 
 environment:
   sdk: ^3.7.2
@@ -50,8 +50,6 @@ dependencies:
   http: ^1.4.0
   package_info_plus: ^8.3.0
   reorderable_grid_view: ^2.2.8
-  flutter_staggered_grid_view: ^0.7.0
-  youtube_player_flutter: ^9.1.2
 
 dev_dependencies:
   flutter_launcher_icons: ^0.14.3


### PR DESCRIPTION
This commit refactors the `YoutubeCard` widget to use `flutter_inappwebview` instead of `youtube_player_flutter` for displaying YouTube videos. This change aims to provide more robust video playback and error handling.

Key changes:

- **Replaced `youtube_player_flutter` with `flutter_inappwebview`:**
    - The `YoutubeCard` now embeds YouTube videos using the standard web embed URL within an `InAppWebView`.
    - This allows for features like pull-to-refresh and better handling of network errors.
- **Introduced `InteractiveWebView` helper widget:**
    - A reusable `InteractiveWebView` widget (similar to one used elsewhere in the app) has been added to `youtube_card.dart`.
    - This widget handles loading progress display, error messages, and a retry mechanism.
- **Improved Video Switching:**
    - A `ValueNotifier<String>` (`_currentVideoUrl`) is now used to manage the current video URL.
    - This triggers a rebuild of the `InteractiveWebView` when a new random video is selected, ensuring the player updates correctly.
- **Layout Fix:**
    - Removed a `Flexible` widget that was causing a layout assertion error.
    - The `InteractiveWebView` is now sized correctly using an `AspectRatio` widget to maintain a 16:9 video format.
- **UI Update:**
    - The card title changed from "Video Player" to "Videos".
- **Dependency Changes:**
    - Removed `youtube_player_flutter` and `flutter_staggered_grid_view` (which was unused) from `pubspec.yaml`.
    - `flutter_inappwebview` is already a project dependency.
- **Version Bump:** Incremented app version to `3.3.4+9`.