### PR TITLE
Refactor: UI consistency, navigation, and dashboard improvements

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -211,17 +211,19 @@ class MyApp extends StatelessWidget {
   }
 }
 
-// NEW: A model to represent a navigation destination.
+// UPDATED: The model now holds separate icons for selected and unselected states.
 class _AppDestination {
   final String id;
   final String label;
   final IconData icon;
+  final IconData selectedIcon; // New property for the filled/selected icon
   final Widget page;
 
   const _AppDestination({
     required this.id,
     required this.label,
     required this.icon,
+    required this.selectedIcon,
     required this.page,
   });
 }
@@ -241,7 +243,7 @@ class ResponsiveScaffold extends StatefulWidget {
 class _ResponsiveScaffoldState extends State<ResponsiveScaffold> {
   int _selectedIndex = 0; // Tracks currently selected navigation index
 
-  // NEW: A master list of all possible destinations.
+  // UPDATED: The master list of destinations now includes both icon variants.
   late final List<_AppDestination> _allDestinations;
 
   @override
@@ -249,11 +251,11 @@ class _ResponsiveScaffoldState extends State<ResponsiveScaffold> {
     super.initState();
     // Initialize the master list here.
     _allDestinations = [
-      _AppDestination(id: 'dashboard', label: 'Dashboard', icon: Icons.dashboard_rounded, page: NativeWelcomePage(onNavigateToTab: _onItemTapped)),
-      _AppDestination(id: 'food', label: 'Food', icon: Icons.restaurant_rounded, page: const RestaurantPage()),
-      _AppDestination(id: 'rewards', label: 'Rewards', icon: Icons.stars_rounded, page: const RewardsPage()),
-      _AppDestination(id: 'hotel', label: 'Hotel', icon: Icons.hotel_rounded, page: const HotelPage()),
-      _AppDestination(id: 'room_key', label: 'Room Key', icon: Icons.key_rounded, page: const RoomKeyPage()),
+      _AppDestination(id: 'dashboard', label: 'Home', icon: Icons.home_outlined, selectedIcon: Icons.home, page: NativeWelcomePage(onNavigateToTab: _onItemTapped)),
+      _AppDestination(id: 'food', label: 'Food', icon: Icons.restaurant_outlined, selectedIcon: Icons.restaurant, page: const RestaurantPage()),
+      _AppDestination(id: 'rewards', label: 'Rewards', icon: Icons.stars, selectedIcon: Icons.stars, page: const RewardsPage()),
+      _AppDestination(id: 'hotel', label: 'Hotel', icon: Icons.hotel_outlined, selectedIcon: Icons.hotel, page: const HotelPage()),
+      _AppDestination(id: 'room_key', label: 'Room Key', icon: Icons.key_outlined, selectedIcon: Icons.key, page: const RoomKeyPage()),
     ];
   }
 
@@ -264,7 +266,7 @@ class _ResponsiveScaffoldState extends State<ResponsiveScaffold> {
     });
   }
 
-  // UPDATED: This function now guarantees the dashboard is always included.
+  // This function now guarantees the dashboard is always included.
   List<_AppDestination> _getVisibleDestinations(ThemeProvider themeProvider) {
     // Start with the dashboard, which is always visible.
     final List<_AppDestination> visible = [_allDestinations.first];
@@ -284,7 +286,7 @@ class _ResponsiveScaffoldState extends State<ResponsiveScaffold> {
     final bool isWideScreen = MediaQuery.of(context).size.width >= 600;
     final themeProvider = Provider.of<ThemeProvider>(context); // Get themeProvider here
 
-    // NEW: Dynamically build the list of destinations that should be visible.
+    // Dynamically build the list of destinations that should be visible.
     final List<_AppDestination> visibleDestinations = _getVisibleDestinations(themeProvider);
 
     // If the currently selected index is out of bounds (because an item was hidden),
@@ -302,7 +304,7 @@ class _ResponsiveScaffoldState extends State<ResponsiveScaffold> {
     // Define the MiniFabItems based on the original FullscreenMenuPage items
     final List<MiniFabItem> menuFabItems = [
       MiniFabItem(
-        icon: Icons.download_for_offline_rounded,
+        icon: Icons.download_for_offline_outlined,
         label: 'Download Menus',
         onTap: () async {
           const url = 'https://www.dropbox.com/scl/fo/7gmlnnjcau1np91ee83ht/h?rlkey=ifj506k3aal7ko7tfecy8oqyq&dl=0';
@@ -319,7 +321,7 @@ class _ResponsiveScaffoldState extends State<ResponsiveScaffold> {
         },
       ),
       MiniFabItem(
-        icon: Icons.settings_rounded,
+        icon: Icons.settings_outlined,
         label: 'Settings',
         onTap: () {
           if (context.mounted) {
@@ -337,7 +339,7 @@ class _ResponsiveScaffoldState extends State<ResponsiveScaffold> {
         },
       ),
       MiniFabItem(
-        icon: Icons.web_rounded,
+        icon: Icons.web_outlined,
         label: 'Visit Blog',
         onTap: () async {
           const url = 'https://hienterprises.blogspot.com';
@@ -357,7 +359,6 @@ class _ResponsiveScaffoldState extends State<ResponsiveScaffold> {
 
 
     return Scaffold(
-      // MODIFIED: Removed AppBar entirely
       body: Row(
         children: [
           if (isWideScreen) _buildNavigationRail(isWideScreen, visibleDestinations),
@@ -369,15 +370,13 @@ class _ResponsiveScaffoldState extends State<ResponsiveScaffold> {
           ),
         ],
       ),
-      // MODIFIED: Conditionally render NavigationBar or BottomNavigationBar
       bottomNavigationBar: isWideScreen ? null : _buildNavigationBar(themeProvider.useMaterial3, visibleDestinations),
-      // NEW: Floating Action Button that expands into mini-FABs for menu items
       floatingActionButton: AnimatedFabMenu(fabItems: menuFabItems),
-      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat, // Position at bottom right
+      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
     );
   }
 
-  // UPDATED: Now takes a list of destinations to build dynamically.
+  // UPDATED: Now uses the `selectedIcon` property for a cleaner implementation.
   NavigationRail _buildNavigationRail(bool isWideScreen, List<_AppDestination> destinations) {
     return NavigationRail(
       selectedIndex: _selectedIndex,
@@ -386,19 +385,27 @@ class _ResponsiveScaffoldState extends State<ResponsiveScaffold> {
           ? NavigationRailLabelType.all
           : NavigationRailLabelType.none,
       destinations: destinations.map((dest) {
-        return NavigationRailDestination(icon: Icon(dest.icon), label: Text(dest.label));
+        return NavigationRailDestination(
+          icon: Icon(dest.icon),
+          selectedIcon: Icon(dest.selectedIcon), // Use the filled icon for the selected state
+          label: Text(dest.label),
+        );
       }).toList(),
     );
   }
 
-  // UPDATED: Now takes a list of destinations to build dynamically.
+  // UPDATED: Now uses the `selectedIcon` property for M3 and dynamic icons for M2.
   Widget _buildNavigationBar(bool useMaterial3, List<_AppDestination> destinations) {
     if (useMaterial3) {
       return NavigationBar(
         selectedIndex: _selectedIndex,
         onDestinationSelected: _onItemTapped,
         destinations: destinations.map((dest) {
-          return NavigationDestination(icon: Icon(dest.icon), label: dest.label);
+          return NavigationDestination(
+            icon: Icon(dest.icon),
+            selectedIcon: Icon(dest.selectedIcon), // Use the filled icon for the selected state
+            label: dest.label,
+          );
         }).toList(),
       );
     } else {
@@ -406,12 +413,17 @@ class _ResponsiveScaffoldState extends State<ResponsiveScaffold> {
       return BottomNavigationBar(
         currentIndex: _selectedIndex,
         onTap: _onItemTapped,
-        type: BottomNavigationBarType.fixed, // Ensures all items are visible and evenly spaced
-        items: destinations.map((dest) {
-          return BottomNavigationBarItem(icon: Icon(dest.icon), label: dest.label);
+        type: BottomNavigationBarType.fixed,
+        // Dynamically build the items, choosing the correct icon based on the selected index.
+        items: destinations.asMap().entries.map((entry) {
+          final int index = entry.key;
+          final _AppDestination dest = entry.value;
+          return BottomNavigationBarItem(
+            icon: Icon(_selectedIndex == index ? dest.selectedIcon : dest.icon),
+            label: dest.label,
+          );
         }).toList(),
       );
     }
   }
 }
-

--- a/lib/settings/about_page.dart
+++ b/lib/settings/about_page.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+class AboutAppPage extends StatefulWidget {
+  const AboutAppPage({super.key});
+
+  @override
+  State<AboutAppPage> createState() => _AboutAppPageState();
+}
+
+class _AboutAppPageState extends State<AboutAppPage> {
+  String _version = '...';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadVersionInfo();
+  }
+
+  Future<void> _loadVersionInfo() async {
+    final info = await PackageInfo.fromPlatform();
+    if (mounted) {
+      setState(() {
+        _version = '${info.version}+${info.buildNumber}';
+      });
+    }
+  }
+
+  // Helper widget to build the info rows, similar to the HTML structure.
+  Widget _buildInfoRow(BuildContext context, {required String title, required String value}) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            value,
+            style: theme.textTheme.bodyLarge,
+          ),
+        ],
+      ),
+    );
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    const double contentMaxWidth = 768.0;
+
+    return Scaffold(
+      // FIXED: The AppBar has been added back to the Scaffold.
+      appBar: AppBar(
+        title: const Text("About App"),
+      ),
+      // The body is a Column to place the footer at the bottom.
+      body: SafeArea(
+        child: Column(
+          children: [
+            // The main content is an Expanded ListView to make it scrollable.
+            Expanded(
+              child: Align(
+                alignment: Alignment.topCenter,
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: contentMaxWidth),
+                  child: ListView(
+                    padding: const EdgeInsets.all(16.0),
+                    children: [
+                      // --- Header Card ---
+                      // This card is no longer needed as the AppBar serves as the header.
+                      // const SizedBox(height: 16), // Removed to bring content up.
+                      // --- Main Content Card ---
+                      Card(
+                        elevation: 0,
+                        color: colorScheme.surfaceVariant.withOpacity(0.5),
+                        clipBehavior: Clip.antiAlias,
+                        child: Padding(
+                          padding: const EdgeInsets.all(16.0),
+                          child: Column(
+                            children: [
+                              // --- Logo Section ---
+                              // UPDATED: Wrapped the Image.network in a ClipRRect to add a corner radius.
+                              ClipRRect(
+                                borderRadius: BorderRadius.circular(12.0), // Adjust the radius as needed
+                                child: Image.network(
+                                  'https://thehighlandcafe.github.io/hioswebcore/assets/pics/logos/logo_new-harmony.png',
+                                  fit: BoxFit.contain,
+                                  loadingBuilder: (context, child, progress) {
+                                    if (progress == null) return child;
+                                    return const SizedBox(
+                                      height: 100,
+                                      child: Center(child: CircularProgressIndicator()),
+                                    );
+                                  },
+                                ),
+                              ),
+                              const SizedBox(height: 24),
+                              // --- Info Box (like the "translucentAboutBox") ---
+                              Card(
+                                elevation: 0,
+                                color: colorScheme.surface.withOpacity(0.6),
+                                child: Padding(
+                                  padding: const EdgeInsets.all(16.0),
+                                  child: Column(
+                                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                                    children: [
+                                      _buildInfoRow(context, title: "App Name", value: "Harmony by The Highland Cafe™"),
+                                      const Divider(),
+                                      _buildInfoRow(context, title: "App Version", value: _version),
+                                      const Divider(),
+                                      _buildInfoRow(context, title: "Built With", value: "Flutter"),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(height: 24),
+                              // --- Description Text ---
+                              const Text(
+                                "Harmony is the successor to HiOSMobile -- the app is now based on Flutter, so is adaptive and cross-platform.\n\nThis app is much faster and easier to maintain than HiOSMobile and HiOSMobile Lite, so we can bring new features to you faster!",
+                                textAlign: TextAlign.center,
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            // --- Footer ---
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Text(
+                "Copyright © The Highland Cafe™ Ltd. 2025. All Rights Reserved.",
+                style: theme.textTheme.bodySmall,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/settings/appearance_settings_page.dart
+++ b/lib/settings/appearance_settings_page.dart
@@ -40,14 +40,14 @@ class AppearanceSettingsPage extends StatelessWidget {
             // --- Theme & Colours Group ---
             const SettingsGroupTitle(title: "Theme & Colours"),
             SettingsListItem(
-              icon: Icons.brightness_6_rounded,
+              icon: Icons.brightness_6_outlined,
               label: "Theme",
               trailing: _buildThemeDropdown(context, themeProvider, colorScheme),
               isFirstItem: true,
               isLastItem: false,
             ),
             SettingsListItem(
-              icon: Icons.format_color_fill_rounded,
+              icon: Icons.format_color_fill_outlined,
               label: "Use Dynamic Colour",
               subtitle: "Uses colours from your wallpaper (Android 12+)",
               trailing: Switch(
@@ -56,21 +56,20 @@ class AppearanceSettingsPage extends StatelessWidget {
                     ? (value) => themeProvider.setUseDynamicColor(value)
                     : null,
               ),
-              isLastItem: false,
+              isLastItem: dynamicColorEnabled,
             ),
-            SettingsListItem(
-              icon: Icons.design_services_rounded,
+            /*SettingsListItem(
+              icon: Icons.interests_outlined,
               label: "Use Material 3 Design",
               subtitle: "Modern UI elements and features",
               trailing: Switch(
                 value: useMaterial3,
                 onChanged: (value) => themeProvider.useMaterial3 = value,
               ),
-              isLastItem: dynamicColorEnabled,
-            ),
+            ),*/
             if (!dynamicColorEnabled)
               SettingsListItem(
-                icon: Icons.color_lens_rounded,
+                icon: Icons.color_lens_outlined,
                 label: "App Colours",
                 trailing: _buildSchemeDropdown(context, themeProvider, colorScheme),
                 isLastItem: true,
@@ -88,7 +87,7 @@ class AppearanceSettingsPage extends StatelessWidget {
               final bool isLast = id == navItemNames.keys.last;
 
               return SettingsListItem(
-                icon: Icons.visibility_rounded, // Using a generic icon for consistency
+                icon: Icons.visibility, // Using a generic icon for consistency
                 label: name,
                 trailing: Switch(
                   value: isVisible,

--- a/lib/settings/settings_page.dart
+++ b/lib/settings/settings_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:package_info_plus/package_info_plus.dart';
 
 // Local Imports
 import '../settings_ui_components.dart';
@@ -9,33 +8,12 @@ import 'appearance_settings_page.dart';
 import 'privacy_policy_page.dart';
 import 'websites_page.dart';
 import 'updates_page.dart';
-import 'apps_services_page.dart';
-import 'socials_page.dart';
+// NEW: Import the new about page
+import 'about_page.dart';
 
 
-class SettingsPage extends StatefulWidget {
+class SettingsPage extends StatelessWidget {
   const SettingsPage({super.key});
-
-  @override
-  State<SettingsPage> createState() => _SettingsPageState();
-}
-
-class _SettingsPageState extends State<SettingsPage> {
-  String _version = '';
-
-  @override
-  void initState() {
-    super.initState();
-    _loadVersionInfo();
-  }
-
-  // Fetches the app version to display in the about dialog.
-  Future<void> _loadVersionInfo() async {
-    final info = await PackageInfo.fromPlatform();
-    setState(() {
-      _version = '${info.version}+${info.buildNumber}';
-    });
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -45,54 +23,38 @@ class _SettingsPageState extends State<SettingsPage> {
         // --- General Group ---
         const SettingsGroupTitle(title: "General"),
         SettingsListItem(
-          icon: Icons.palette_rounded,
+          icon: Icons.palette_outlined,
           label: "Appearance",
           onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const AppearanceSettingsPage()),
           ),
           isFirstItem: true,
         ),
         SettingsListItem(
-          icon: Icons.system_update_rounded,
+          icon: Icons.system_update,
           label: "Updates",
           onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const UpdatesPage()),
           ),
         ),
         SettingsListItem(
-          icon: Icons.apps_rounded,
-          label: "Apps & Services",
-          onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const AppsServicesPage()),
-          ),
-        ),
-        SettingsListItem(
-          icon: Icons.language_rounded,
+          icon: Icons.language_outlined,
           label: "Websites",
           onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const WebsitesPage()),
           ),
-        ),
-        SettingsListItem(
-          icon: Icons.people_rounded,
-          label: "Socials",
-          onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const SocialsPage()),
-          ),
+          // UPDATED: isLastItem is now true
           isLastItem: true,
         ),
 
         // --- About Group ---
         const SettingsGroupTitle(title: "About"),
         SettingsListItem(
-          icon: Icons.perm_device_info_rounded,
+          icon: Icons.info_outline,
           label: "About App",
-          onTap: () => showAboutDialog(
-            context: context,
-            applicationName: 'Harmony by The Highland Cafe',
-            applicationVersion: _version,
-            applicationLegalese:
-            'Copyright © The Highland Cafe™ Ltd. 2025. All rights Reserved.',
-          ),
+          // UPDATED: onTap now navigates to the new AboutAppPage.
+          onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const AboutAppPage())),
           isFirstItem: true,
         ),
         SettingsListItem(
-          icon: Icons.privacy_tip_rounded,
+          icon: Icons.privacy_tip_outlined,
           label: "Privacy Policy",
           onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const PrivacyPolicyPage()),
           ),

--- a/lib/settings/updates_page.dart
+++ b/lib/settings/updates_page.dart
@@ -12,7 +12,7 @@ class UpdatesPage extends StatefulWidget {
 }
 
 class _UpdatesPageState extends State<UpdatesPage> {
-  String _version = '';
+  String _version = '...';
 
   @override
   void initState() {
@@ -22,9 +22,11 @@ class _UpdatesPageState extends State<UpdatesPage> {
 
   Future<void> _loadVersionInfo() async {
     final info = await PackageInfo.fromPlatform();
-    setState(() {
-      _version = '${info.version}+${info.buildNumber}';
-    });
+    if (mounted) {
+      setState(() {
+        _version = '${info.version}+${info.buildNumber}';
+      });
+    }
   }
 
   final String _latestUpdateUrl = 'https://github.com/aarjay123/harmonyapp/releases/latest';
@@ -33,69 +35,72 @@ class _UpdatesPageState extends State<UpdatesPage> {
 
   Future<void> _launchExternalUrl(BuildContext context, String url) async {
     final uri = Uri.parse(url);
-    if (await canLaunchUrl(uri)) {
-      await launchUrl(uri);
-    } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Could not launch the website.')),
-      );
+    if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not launch the website.')),
+        );
+      }
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-
     return SettingsPageTemplate(
       title: "Updates",
       children: [
+        // --- Update Harmony Group ---
         const SettingsGroupTitle(title: "Update Harmony"),
         SettingsListItem(
           icon: Icons.download_rounded,
-          label: "Manually Update Harmony",
-          subtitle:
-          "Download the latest app installer file.\n1. Tap here, then tap the installer matching your OS.\n2. Install the update how you usually would.",
+          label: "Download from GitHub",
+          subtitle: "Get the latest version from our official releases page.",
+          onTap: () => _launchExternalUrl(context, _latestUpdateUrl),
+          isFirstItem: true,
+        ),
+        SettingsListItem(
+          icon: Icons.update_rounded,
+          label: "Set Up Auto-Updates",
+          subtitle: "Visit our site to learn how to get automatic updates on Android.",
+          onTap: () => _launchExternalUrl(context, _autoUpdateUrl),
+          isLastItem: true,
+        ),
+
+        // --- Notifications Group ---
+        const SettingsGroupTitle(title: "Stay Informed"),
+        SettingsListItem(
+          icon: Icons.notifications_active_rounded,
+          label: "Join our Discord",
+          subtitle: "Get notified every time we release a new update.",
+          onTap: () => _launchExternalUrl(context, _discordUrl),
+          isFirstItem: true,
+          isLastItem: true,
+        ),
+
+        // --- Version Information Group ---
+        const SettingsGroupTitle(title: "Version Information"),
+        SettingsListItem(
+          icon: Icons.new_releases_rounded,
+          label: "What's New?",
+          subtitle: "See the official release notes for the latest version.",
           onTap: () => _launchExternalUrl(context, _latestUpdateUrl),
           isFirstItem: true,
         ),
         SettingsListItem(
           icon: Icons.info_rounded,
-          label: "This version: $_version",
-          subtitle: null,
-          onTap: () {}, // no action, but needed for InkWell
-        ),
-        SettingsListItem(
-          icon: Icons.update_rounded,
-          label: "Auto-Update Harmony on Android",
-          subtitle: "Learn how to update Harmony on Android automatically on our website.",
-          onTap: () => _launchExternalUrl(context, _autoUpdateUrl),
+          label: "Current Version",
+          subtitle: "You are running version $_version",
+          // This item is purely informational, so it has no onTap action.
+          // The UI component will automatically hide the chevron arrow.
           isLastItem: true,
         ),
 
-        const SettingsGroupTitle(title: "Update notifications and more"),
-        SettingsListItem(
-          icon: Icons.notifications_active_rounded,
-          label: "Update Notifications",
-          subtitle: "Join our Discord server to get notified every time we update Harmony.",
-          onTap: () => _launchExternalUrl(context, _discordUrl), // no action, but needed for InkWell
-          isFirstItem: true,
-        ),
-        SettingsListItem(
-          icon: Icons.new_releases_rounded,
-          label: "What's New?",
-          subtitle: null,
-          onTap: () => _launchExternalUrl(context, _latestUpdateUrl),
-          isLastItem: true,
-        ),
-
+        // --- About Group ---
         const SettingsGroupTitle(title: "About"),
         SettingsListItem(
           icon: Icons.info_outline,
           label: "About Harmony",
-          subtitle:
-          "Harmony is the successor to HiOSMobile -- the app is now based on Flutter, so is adaptive and cross-platform.\nThis app is much faster and easier to maintain than HiOSMobile and HiOSMobile Lite, so we can bring new features to you faster!",
-          onTap: () {}, //
+          subtitle: "Harmony is the successor to HiOSMobile -- the app is now based on Flutter, so is adaptive and cross-platform.\nThis app is much faster and easier to maintain than HiOSMobile and HiOSMobile Lite, so we can bring new features to you faster!",
           isFirstItem: true,
           isLastItem: true,
         ),

--- a/lib/widgets/at_a_glance_card.dart
+++ b/lib/widgets/at_a_glance_card.dart
@@ -310,7 +310,7 @@ class _AtAGlanceCardState extends State<AtAGlanceCard> {
 
     return Card(
       elevation: 0, // No shadow for this card, as it's part of the main layout
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(0.0)),
       color: theme.colorScheme.secondaryContainer, // Uses the secondary container color
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),

--- a/lib/widgets/calendar_card.dart
+++ b/lib/widgets/calendar_card.dart
@@ -64,7 +64,7 @@ class _CalendarCardState extends State<CalendarCard> {
 
     return Card(
       elevation: 0,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(0.0)),
       color: colorScheme.surfaceVariant,
       child: Padding(
         padding: const EdgeInsets.all(20.0),

--- a/lib/widgets/countdown_card.dart
+++ b/lib/widgets/countdown_card.dart
@@ -136,7 +136,7 @@ class _CountdownCardState extends State<CountdownCard> {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20.0)),
         title: const Text('Add New Countdown'),
         content: TextField(
           controller: _eventNameController,
@@ -189,8 +189,8 @@ class _CountdownCardState extends State<CountdownCard> {
 
     return Card(
       elevation: 0,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
-      color: colorScheme.surfaceContainer,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(0.0)),
+      color: colorScheme.primaryContainer,
       child: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(

--- a/lib/widgets/daily_affirmation_card.dart
+++ b/lib/widgets/daily_affirmation_card.dart
@@ -74,7 +74,7 @@ class _DailyAffirmationCardState extends State<DailyAffirmationCard> {
 
     return Card(
       elevation: 0, // Flat card design
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
       color: colorScheme.secondaryContainer, // Uses secondary container color for differentiation
       child: Padding(
         padding: const EdgeInsets.all(20.0), // Consistent internal padding

--- a/lib/widgets/news_feed_card.dart
+++ b/lib/widgets/news_feed_card.dart
@@ -119,7 +119,7 @@ class _NewsFeedCardState extends State<NewsFeedCard> {
 
     return Card(
       elevation: 0, // Flat card design
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(0.0)),
       color: colorScheme.tertiaryContainer, // Uses tertiary container color for distinct look
       child: Padding(
         padding: const EdgeInsets.all(20.0), // Consistent internal padding

--- a/lib/widgets/quick_actions_card.dart
+++ b/lib/widgets/quick_actions_card.dart
@@ -20,8 +20,9 @@ class QuickAction {
 // You can add or remove items from this list.
 const List<QuickAction> allAvailableActions = [
   QuickAction(id: 'food', label: 'Order Food', icon: Icons.restaurant_rounded, tabIndex: 1),
-  QuickAction(id: 'stay', label: 'Book Stay', icon: Icons.hotel_rounded, tabIndex: 2),
-  QuickAction(id: 'roomkey', label: 'View Room Key', icon: Icons.key_rounded, tabIndex: 3),
+  QuickAction(id: 'hirewards', label: 'HiRewards', icon: Icons.stars_rounded, tabIndex: 2),
+  QuickAction(id: 'stay', label: 'Book a Room', icon: Icons.hotel_rounded, tabIndex: 3),
+  QuickAction(id: 'roomkey', label: 'View Room Key', icon: Icons.key_rounded, tabIndex: 4),
 ];
 
 class QuickActionsCard extends StatefulWidget {
@@ -133,7 +134,7 @@ class _QuickActionsCardState extends State<QuickActionsCard> {
     return Card(
       elevation: 0,
       color: theme.colorScheme.surfaceVariant.withAlpha(150),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20.0)),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(0.0)),
       child: Padding(
         padding: const EdgeInsets.all(20.0),
         child: Column(

--- a/lib/widgets/quick_links_card.dart
+++ b/lib/widgets/quick_links_card.dart
@@ -136,8 +136,8 @@ class _QuickLinksCardState extends State<QuickLinksCard> {
 
     return Card(
       elevation: 0, // Flat card design
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
-      color: colorScheme.surfaceContainerHighest, // Uses a distinct surface color
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(0.0)),
+      color: colorScheme.tertiaryContainer, // Uses a distinct surface color
       child: Padding(
         padding: const EdgeInsets.all(20.0), // Consistent internal padding
         child: Column(

--- a/lib/widgets/quick_notes_card.dart
+++ b/lib/widgets/quick_notes_card.dart
@@ -52,7 +52,7 @@ class _QuickNotesCardState extends State<QuickNotesCard> {
 
     return Card(
       elevation: 0, // Flat card design
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(0.0)),
       color: colorScheme.primaryContainer, // Can choose a different color scheme if desired
       child: Padding(
         padding: const EdgeInsets.all(20.0), // Consistent internal padding

--- a/lib/widgets/todo_list_card.dart
+++ b/lib/widgets/todo_list_card.dart
@@ -132,8 +132,8 @@ class _TodoListCardState extends State<TodoListCard> {
 
     return Card(
       elevation: 0,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
-      color: colorScheme.surfaceContainer,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(0.0)),
+      color: colorScheme.secondaryContainer,
       child: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(

--- a/lib/widgets/youtube_card.dart
+++ b/lib/widgets/youtube_card.dart
@@ -176,7 +176,7 @@ class _YoutubeCardState extends State<YoutubeCard> {
 
     return Card(
       elevation: 0,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(0.0)),
       color: colorScheme.surfaceVariant,
       clipBehavior: Clip.antiAlias,
       child: Column(
@@ -186,7 +186,7 @@ class _YoutubeCardState extends State<YoutubeCard> {
             padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
             child: Row(
               children: [
-                Icon(Icons.play_circle_fill_rounded, color: colorScheme.onSurfaceVariant),
+                Icon(Icons.ondemand_video_outlined, color: colorScheme.onSurfaceVariant),
                 const SizedBox(width: 12),
                 Text(
                   "Videos",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 3.3.4+9
+version: 3.4.0+10
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
This commit introduces significant UI refinements, enhances navigation, and improves the stability and appearance of the dashboard.

**UI & Styling:**
- **Card Styling:** All dashboard cards now have a `borderRadius` of `0.0` for a more unified, flatter design within their containers.
    - Specific cards like `DailyAffirmationCard` retain a slight radius (`8.0`).
    - `CountdownCard` dialog shape updated to `borderRadius: 20.0`.
- **Iconography:** Updated various icons throughout the app to use outlined variants for a consistent Material Design style (e.g., settings icons, FAB menu icons, navigation icons).
- **Home/Dashboard:**
    - Single-column layout widgets now have rounded top/bottom corners for the first/last items and a slight vertical spacing between cards.
    - Adjusted padding and spacing for various elements on the Home screen for a cleaner look.
    - "Edit Widgets" button text changed to "Done Editing" when in edit mode.
- **Settings:**
    - **About Page:** Introduced a new dedicated "About App" page (`about_page.dart`) replacing the previous `showAboutDialog`. This page displays app name, version, build info, and a description.
    - **Updates Page:** Refined layout and text for clarity. "About Harmony" section text updated.
    - `AppearanceSettingsPage`: Minor icon updates. Temporarily commented out "Use Material 3 Design" toggle.
- **Quick Links Card:** Changed `colorScheme.surfaceContainerHighest` to `colorScheme.tertiaryContainer`.
- **Quick Actions Card:** Updated labels and tab indices for quick actions: "Book Stay" to "Book a Room", added "HiRewards".
- **Todo List Card:** Changed color from `surfaceContainer` to `secondaryContainer`.
- **Countdown Card:** Changed color from `surfaceContainer` to `primaryContainer`.

**Navigation:**
- **`_AppDestination` Model:** Updated to include `selectedIcon` for distinct filled icons when a navigation item is active.
- **Navigation Components:** `NavigationRail`, `NavigationBar` (M3), and `BottomNavigationBar` (M2) now use the `selectedIcon` for the active destination, providing clearer visual feedback.
- **Home Tab Label:** Changed from "Dashboard" to "Home".

**Dashboard (`home.dart`):**
- **Initialization Logic:** Refactored `initState` into a new `_initializeDashboard` async method. This method now:
    - Sets an `_isLoading` flag to display a `CircularProgressIndicator` during setup.
    - Loads countdown events and user widget order from `SharedPreferences` concurrently.
    - Builds `_availableWidgets` map *after* all data is loaded.
    - Robustly determines `_userWidgetOrder`, handling cases where saved order is missing or contains non-existent widgets, and adding new default widgets.
- **Widget Order & Saving:**
    - Calls to `_saveUserWidgetOrder()` are now reliably placed within `setState` calls when adding, removing, or reordering widgets to ensure changes are persisted correctly.
    - Corrected reorder logic in `_buildSingleColumnLayout`.
- **Widget Building:**
    - `_buildWidgetTile` now wraps the widget's builder in a `Theme` to override card margins and shape, ensuring consistent appearance.
    - YouTube card is now conditionally excluded on web (`if (!kIsWeb)`).
- **State Management:** Removed redundant loading of countdown events; it's handled in `_initializeDashboard`.

**Pubspec:**
- Version incremented to `3.4.0+10`.