### PR TITLE
Refactor: Add video ads feature and refactor main app structure

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,0 +1,104 @@
+// lib/app.dart
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:dynamic_color/dynamic_color.dart';
+
+import 'theme_provider.dart'; // Assumed path
+import 'colour_scheme.dart'; // Assumed path
+import 'global_slide_transition_builder.dart'; // Assumed path
+import 'widgets/responsive_scaffold.dart'; // Import the refactored scaffold
+
+// Main app widget, builds MaterialApp with theming based on dynamic color support and user preference
+class Harmony extends StatelessWidget {
+  final bool dynamicColourSupported; // Passed from AppLoader, device capability flag
+
+  const Harmony({Key? key, required this.dynamicColourSupported}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return DynamicColorBuilder(
+      // Builder provides dynamic light and dark color schemes if available
+      builder: (ColorScheme? lightDynamic, ColorScheme? darkDynamic) {
+        final themeProvider = Provider.of<ThemeProvider>(context);
+
+        // Determine if dynamic color should be used based on device and user settings
+        final useDynamic =
+            themeProvider.dynamicColorEnabled && dynamicColourSupported;
+
+        // Common CardThemeData definition based on Material 3 toggle
+        final CardThemeData commonCardTheme = CardThemeData(
+          // Sharper corners for Material 2, softer for Material 3
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(themeProvider.useMaterial3 ? 12.0 : 8.0),
+          ),
+          // More pronounced shadow for Material 2, subtle for Material 3
+          elevation: themeProvider.useMaterial3 ? 1.0 : 4.0,
+        );
+
+        if (useDynamic) {
+          // If dynamic colors enabled and supported, build MaterialApp using them
+          return _buildMaterialApp(
+            themeProvider: themeProvider,
+            lightScheme: lightDynamic ?? lightColorScheme,
+            darkScheme: darkDynamic ?? darkColorScheme,
+            commonCardTheme: commonCardTheme,
+          );
+        }
+
+        // Otherwise, build app with user's selected color scheme (no dynamic color)
+        final ColorScheme lightScheme = themeProvider.currentColorScheme;
+        final ColorScheme darkScheme = ColorScheme.fromSeed(
+          seedColor: lightScheme.primary,
+          brightness: Brightness.dark,
+        );
+
+        return _buildMaterialApp(
+          themeProvider: themeProvider,
+          lightScheme: lightScheme,
+          darkScheme: darkScheme,
+          commonCardTheme: commonCardTheme,
+        );
+      },
+    );
+  }
+
+  // Helper method to build the MaterialApp to reduce code duplication
+  MaterialApp _buildMaterialApp({
+    required ThemeProvider themeProvider,
+    required ColorScheme lightScheme,
+    required ColorScheme darkScheme,
+    required CardThemeData commonCardTheme,
+  }) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      title: 'Harmony',
+      themeMode: themeProvider.themeMode,
+      theme: ThemeData(
+        useMaterial3: themeProvider.useMaterial3,
+        colorScheme: lightScheme,
+        textTheme: ThemeData.light().textTheme.apply(fontFamily: 'Outfit'),
+        cardTheme: commonCardTheme,
+        pageTransitionsTheme: PageTransitionsTheme(
+          builders: {
+            for (final platform in TargetPlatform.values)
+              platform: GlobalSlidePageTransitionsBuilder(),
+          },
+        ),
+      ),
+      darkTheme: ThemeData(
+        useMaterial3: themeProvider.useMaterial3,
+        colorScheme: darkScheme,
+        textTheme: ThemeData.dark().textTheme.apply(fontFamily: 'Outfit'),
+        cardTheme: commonCardTheme,
+        pageTransitionsTheme: PageTransitionsTheme(
+          builders: {
+            for (final platform in TargetPlatform.values)
+              platform: GlobalSlidePageTransitionsBuilder(),
+          },
+        ),
+      ),
+      home: ResponsiveScaffold(dynamicColorSupported: dynamicColourSupported),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,32 +1,15 @@
+// lib/main.dart
+
 // Import Flutter core libraries
-import 'package:flutter/foundation.dart' show kIsWeb; // For platform detection if needed
 import 'package:flutter/material.dart';
 
 // Import third-party packages
-import 'package:provider/provider.dart'; // State management
-import 'package:dynamic_color/dynamic_color.dart'; // For Material You dynamic colors (Android 12+)
-// InAppWebView might still be used by other sub-pages, but FullscreenMenuPage is replaced
-import 'package:flutter_inappwebview/flutter_inappwebview.dart';
-import 'package:url_launcher/url_launcher.dart'; // NEW: For canLaunchUrl, launchUrl, LaunchMode
+import 'package:provider/provider.dart';
 
-// Import your own app files for theming, helpers, and UI components
-import 'theme_provider.dart'; // Custom ThemeProvider managing theme state and preferences
-import 'colour_scheme.dart'; // Defines your app's color schemes
-import 'device_info_helper.dart'; // Helper for checking device capabilities like dynamic color support
-import 'global_slide_transition_builder.dart'; // Custom page transitions (e.g., GlobalSlidePageTransitionsBuilder)
-
-// Import your fragments (pages)
-import 'fragments/home.dart';
-import 'fragments/restaurant.dart';
-import 'fragments/rewards_page.dart';
-import 'fragments/hotel.dart';
-import 'fragments/roomkey.dart';
-
-import 'settings/settings_page.dart';
-import 'helpcenter/helpcenter_page.dart';
-
-// NEW: Import the custom AnimatedFabMenu widget
-import 'widgets/animated_fab_menu.dart'; // Make sure this path is correct
+// Import your own app files
+import 'theme_provider.dart'; // Assumed path
+import 'device_info_helper.dart'; // Assumed path
+import 'app.dart'; // The new root app widget
 
 // The main entry point of the Flutter app
 void main() {
@@ -34,7 +17,7 @@ void main() {
   runApp(const AppLoader()); // Runs the root widget AppLoader
 }
 
-// Stateful widget to handle async initialization before showing main app
+// Stateful widget to handle async initialization before showing main app.
 class AppLoader extends StatefulWidget {
   const AppLoader({Key? key}) : super(key: key);
 
@@ -70,21 +53,25 @@ class _AppLoaderState extends State<AppLoader> {
       }
 
       // Update state with loaded provider instance, triggers UI rebuild
-      setState(() {
-        _themeProvider = themeProvider;
-      });
+      if (mounted) {
+        setState(() {
+          _themeProvider = themeProvider;
+        });
+      }
     } catch (e, st) {
       // On error, log and set error flag to show error UI
       debugPrint('Failed to init theme: $e\n$st');
-      setState(() {
-        _error = true;
-      });
+      if (mounted) {
+        setState(() {
+          _error = true;
+        });
+      }
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    // If error occurred or theme provider is still null (loading), show error message
+    // If error occurred or theme provider is still null (loading), show error/loading UI
     if (_error || _themeProvider == null) {
       return const MaterialApp(
         home: Scaffold(
@@ -94,336 +81,10 @@ class _AppLoaderState extends State<AppLoader> {
     }
 
     // Provide the loaded ThemeProvider to the widget subtree via Provider package
+    // We're using the 'Harmony' widget as requested in the previous step.
     return ChangeNotifierProvider.value(
       value: _themeProvider!,
-      child: MyApp(dynamicColorSupported: _dynamicColorSupported),
+      child: Harmony(dynamicColourSupported: _dynamicColorSupported),
     );
-  }
-}
-
-// Main app widget, builds MaterialApp with theming based on dynamic color support and user preference
-class MyApp extends StatelessWidget {
-  final bool dynamicColorSupported; // Passed from AppLoader, device capability flag
-
-  const MyApp({Key? key, required this.dynamicColorSupported}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return DynamicColorBuilder(
-      // Builder provides dynamic light and dark color schemes if available
-      builder: (ColorScheme? lightDynamic, ColorScheme? darkDynamic) {
-        final themeProvider = Provider.of<ThemeProvider>(context);
-
-        // Determine if dynamic color should be used based on device and user settings
-        final useDynamic =
-            themeProvider.dynamicColorEnabled && dynamicColorSupported;
-
-        // Common CardThemeData definition based on Material 3 toggle
-        final CardThemeData commonCardTheme = CardThemeData( // Changed from CardTheme to CardThemeData
-          // Sharper corners for Material 2, softer for Material 3
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(themeProvider.useMaterial3 ? 12.0 : 8.0),
-          ),
-          // More pronounced shadow for Material 2, subtle for Material 3
-          elevation: themeProvider.useMaterial3 ? 1.0 : 4.0,
-        );
-
-
-        if (useDynamic) {
-          // If dynamic colors enabled and supported, build MaterialApp using them
-          return MaterialApp(
-            debugShowCheckedModeBanner: false,
-            title: 'Harmony',
-            themeMode: themeProvider.themeMode,
-            theme: ThemeData(
-              useMaterial3: themeProvider.useMaterial3, // Enable Material 3 design
-              colorScheme: lightDynamic ?? lightColorScheme, // Use dynamic or fallback light scheme
-              textTheme: ThemeData.light().textTheme.apply(fontFamily: 'Outfit'), // Custom font
-              cardTheme: commonCardTheme, // Apply the common card theme
-              // FIXED: Removed 'const' because the for-loop makes it a non-constant expression.
-              pageTransitionsTheme: PageTransitionsTheme(
-                builders: {
-                  // Apply custom slide transition on all platforms
-                  for (final platform in TargetPlatform.values)
-                    platform: GlobalSlidePageTransitionsBuilder(),
-                },
-              ),
-            ),
-            darkTheme: ThemeData(
-              useMaterial3: themeProvider.useMaterial3,
-              colorScheme: darkDynamic ?? darkColorScheme, // Use dynamic or fallback dark scheme
-              textTheme: ThemeData.dark().textTheme.apply(fontFamily: 'Outfit'),
-              cardTheme: commonCardTheme, // Apply the common card theme
-              // FIXED: Removed 'const' because the for-loop makes it a non-constant expression.
-              pageTransitionsTheme: PageTransitionsTheme(
-                builders: {
-                  for (final platform in TargetPlatform.values)
-                    platform: GlobalSlidePageTransitionsBuilder(),
-                },
-              ),
-            ),
-            // Main app content scaffold
-            home: ResponsiveScaffold(dynamicColorSupported: dynamicColorSupported),
-          );
-        }
-
-        // Otherwise, build app with user's selected color scheme (no dynamic color)
-        final ColorScheme lightScheme = themeProvider.currentColorScheme;
-        final ColorScheme darkScheme = ColorScheme.fromSeed(
-          seedColor: lightScheme.primary,
-          brightness: Brightness.dark,
-        );
-
-        return MaterialApp(
-          debugShowCheckedModeBanner: false,
-          title: 'Harmony',
-          themeMode: themeProvider.themeMode,
-          theme: ThemeData(
-            useMaterial3: themeProvider.useMaterial3,
-            colorScheme: lightScheme,
-            textTheme: ThemeData.light().textTheme.apply(fontFamily: 'Outfit'),
-            cardTheme: commonCardTheme, // Apply the common card theme
-            // FIXED: Removed 'const' because the for-loop makes it a non-constant expression.
-            pageTransitionsTheme: PageTransitionsTheme(
-              builders: {
-                for (final platform in TargetPlatform.values)
-                  platform: GlobalSlidePageTransitionsBuilder(),
-              },
-            ),
-          ),
-          darkTheme: ThemeData(
-            useMaterial3: themeProvider.useMaterial3,
-            colorScheme: darkScheme,
-            textTheme: ThemeData.dark().textTheme.apply(fontFamily: 'Outfit'),
-            cardTheme: commonCardTheme, // Apply the common card theme
-            // FIXED: Removed 'const' because the for-loop makes it a non-constant expression.
-            pageTransitionsTheme: PageTransitionsTheme(
-              builders: {
-                for (final platform in TargetPlatform.values)
-                  platform: GlobalSlidePageTransitionsBuilder(),
-              },
-            ),
-          ),
-          home: ResponsiveScaffold(dynamicColorSupported: dynamicColorSupported),
-        );
-      },
-    );
-  }
-}
-
-// UPDATED: The model now holds separate icons for selected and unselected states.
-class _AppDestination {
-  final String id;
-  final String label;
-  final IconData icon;
-  final IconData selectedIcon; // New property for the filled/selected icon
-  final Widget page;
-
-  const _AppDestination({
-    required this.id,
-    required this.label,
-    required this.icon,
-    required this.selectedIcon,
-    required this.page,
-  });
-}
-
-
-// ResponsiveScaffold is the main UI scaffold that adapts navigation for wide or narrow screens
-class ResponsiveScaffold extends StatefulWidget {
-  final bool dynamicColorSupported; // Whether dynamic color is supported on this device
-
-  const ResponsiveScaffold({Key? key, required this.dynamicColorSupported})
-      : super(key: key);
-
-  @override
-  State<ResponsiveScaffold> createState() => _ResponsiveScaffoldState();
-}
-
-class _ResponsiveScaffoldState extends State<ResponsiveScaffold> {
-  int _selectedIndex = 0; // Tracks currently selected navigation index
-
-  // UPDATED: The master list of destinations now includes both icon variants.
-  late final List<_AppDestination> _allDestinations;
-
-  @override
-  void initState() {
-    super.initState();
-    // Initialize the master list here.
-    _allDestinations = [
-      _AppDestination(id: 'dashboard', label: 'Home', icon: Icons.home_outlined, selectedIcon: Icons.home, page: NativeWelcomePage(onNavigateToTab: _onItemTapped)),
-      _AppDestination(id: 'food', label: 'Food', icon: Icons.restaurant_outlined, selectedIcon: Icons.restaurant, page: const RestaurantPage()),
-      _AppDestination(id: 'rewards', label: 'Rewards', icon: Icons.stars, selectedIcon: Icons.stars, page: const RewardsPage()),
-      _AppDestination(id: 'hotel', label: 'Hotel', icon: Icons.hotel_outlined, selectedIcon: Icons.hotel, page: const HotelPage()),
-      _AppDestination(id: 'room_key', label: 'Room Key', icon: Icons.key_outlined, selectedIcon: Icons.key, page: const RoomKeyPage()),
-    ];
-  }
-
-
-  void _onItemTapped(int index) {
-    setState(() {
-      _selectedIndex = index;
-    });
-  }
-
-  // This function now guarantees the dashboard is always included.
-  List<_AppDestination> _getVisibleDestinations(ThemeProvider themeProvider) {
-    // Start with the dashboard, which is always visible.
-    final List<_AppDestination> visible = [_allDestinations.first];
-
-    // Filter the rest of the destinations based on user settings.
-    final otherVisible = _allDestinations.skip(1).where((dest) {
-      return themeProvider.visibleDestinations[dest.id] ?? true;
-    });
-
-    visible.addAll(otherVisible);
-    return visible;
-  }
-
-
-  @override
-  Widget build(BuildContext context) {
-    final bool isWideScreen = MediaQuery.of(context).size.width >= 600;
-    final themeProvider = Provider.of<ThemeProvider>(context); // Get themeProvider here
-
-    // Dynamically build the list of destinations that should be visible.
-    final List<_AppDestination> visibleDestinations = _getVisibleDestinations(themeProvider);
-
-    // If the currently selected index is out of bounds (because an item was hidden),
-    // reset to the first page.
-    if (_selectedIndex >= visibleDestinations.length) {
-      // Use a post-frame callback to avoid calling setState during a build.
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        setState(() {
-          _selectedIndex = 0;
-        });
-      });
-    }
-
-
-    // Define the MiniFabItems based on the original FullscreenMenuPage items
-    final List<MiniFabItem> menuFabItems = [
-      MiniFabItem(
-        icon: Icons.download_for_offline_outlined,
-        label: 'Download Menus',
-        onTap: () async {
-          const url = 'https://www.dropbox.com/scl/fo/7gmlnnjcau1np91ee83ht/h?rlkey=ifj506k3aal7ko7tfecy8oqyq&dl=0';
-          final uri = Uri.parse(url);
-          if (await canLaunchUrl(uri)) {
-            await launchUrl(uri, mode: LaunchMode.externalApplication);
-          } else {
-            if (context.mounted) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('Could not launch $url')),
-              );
-            }
-          }
-        },
-      ),
-      MiniFabItem(
-        icon: Icons.settings_outlined,
-        label: 'Settings',
-        onTap: () {
-          if (context.mounted) {
-            Navigator.push(context, MaterialPageRoute(builder: (_) => const SettingsPage()));
-          }
-        },
-      ),
-      MiniFabItem(
-        icon: Icons.help_outline_rounded,
-        label: 'Help',
-        onTap: () {
-          if (context.mounted) {
-            Navigator.push(context, MaterialPageRoute(builder: (_) => const HelpcenterPage()));
-          }
-        },
-      ),
-      MiniFabItem(
-        icon: Icons.web_outlined,
-        label: 'Visit Blog',
-        onTap: () async {
-          const url = 'https://hienterprises.blogspot.com';
-          final uri = Uri.parse(url);
-          if (await canLaunchUrl(uri)) {
-            await launchUrl(uri, mode: LaunchMode.externalApplication);
-          } else {
-            if (context.mounted) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('Could not launch $url')),
-              );
-            }
-          }
-        },
-      ),
-    ];
-
-
-    return Scaffold(
-      body: Row(
-        children: [
-          if (isWideScreen) _buildNavigationRail(isWideScreen, visibleDestinations),
-          Expanded(
-            // Show the selected page from the visible list.
-            child: visibleDestinations.isEmpty
-                ? const Center(child: Text("An error has occurred.")) // Should not happen with dashboard always visible
-                : visibleDestinations[_selectedIndex].page,
-          ),
-        ],
-      ),
-      bottomNavigationBar: isWideScreen ? null : _buildNavigationBar(themeProvider.useMaterial3, visibleDestinations),
-      floatingActionButton: AnimatedFabMenu(fabItems: menuFabItems),
-      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
-    );
-  }
-
-  // UPDATED: Now uses the `selectedIcon` property for a cleaner implementation.
-  NavigationRail _buildNavigationRail(bool isWideScreen, List<_AppDestination> destinations) {
-    return NavigationRail(
-      selectedIndex: _selectedIndex,
-      onDestinationSelected: _onItemTapped,
-      labelType: isWideScreen
-          ? NavigationRailLabelType.all
-          : NavigationRailLabelType.none,
-      destinations: destinations.map((dest) {
-        return NavigationRailDestination(
-          icon: Icon(dest.icon),
-          selectedIcon: Icon(dest.selectedIcon), // Use the filled icon for the selected state
-          label: Text(dest.label),
-        );
-      }).toList(),
-    );
-  }
-
-  // UPDATED: Now uses the `selectedIcon` property for M3 and dynamic icons for M2.
-  Widget _buildNavigationBar(bool useMaterial3, List<_AppDestination> destinations) {
-    if (useMaterial3) {
-      return NavigationBar(
-        selectedIndex: _selectedIndex,
-        onDestinationSelected: _onItemTapped,
-        destinations: destinations.map((dest) {
-          return NavigationDestination(
-            icon: Icon(dest.icon),
-            selectedIcon: Icon(dest.selectedIcon), // Use the filled icon for the selected state
-            label: dest.label,
-          );
-        }).toList(),
-      );
-    } else {
-      // Material 2 style BottomNavigationBar
-      return BottomNavigationBar(
-        currentIndex: _selectedIndex,
-        onTap: _onItemTapped,
-        type: BottomNavigationBarType.fixed,
-        // Dynamically build the items, choosing the correct icon based on the selected index.
-        items: destinations.asMap().entries.map((entry) {
-          final int index = entry.key;
-          final _AppDestination dest = entry.value;
-          return BottomNavigationBarItem(
-            icon: Icon(_selectedIndex == index ? dest.selectedIcon : dest.icon),
-            label: dest.label,
-          );
-        }).toList(),
-      );
-    }
   }
 }

--- a/lib/models/app_destination.dart
+++ b/lib/models/app_destination.dart
@@ -1,0 +1,21 @@
+// lib/models/app_destination.dart
+
+import 'package:flutter/material.dart';
+
+// A model to represent a navigation destination.
+// This now includes the `selectedIcon` property from your updated code.
+class AppDestination {
+  final String id;
+  final String label;
+  final IconData icon;
+  final IconData selectedIcon; // New property for the filled/selected icon
+  final Widget page;
+
+  const AppDestination({
+    required this.id,
+    required this.label,
+    required this.icon,
+    required this.selectedIcon,
+    required this.page,
+  });
+}

--- a/lib/settings/settings_page.dart
+++ b/lib/settings/settings_page.dart
@@ -1,22 +1,126 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 // Local Imports
 import '../settings_ui_components.dart';
+import '../theme_provider.dart';
 import 'appearance_settings_page.dart';
-
-// Placeholder imports for navigation
 import 'privacy_policy_page.dart';
 import 'websites_page.dart';
 import 'updates_page.dart';
-// NEW: Import the new about page
 import 'about_page.dart';
 
-
-class SettingsPage extends StatelessWidget {
+class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
 
   @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  // Controller for the text field in the dialog.
+  final TextEditingController _codeController = TextEditingController();
+
+  // The secret code to disable ads.
+  static const String _secretCode = "HIOSMOBILE2021";
+
+  @override
+  void dispose() {
+    _codeController.dispose();
+    super.dispose();
+  }
+
+  // Helper to launch a URL.
+  Future<void> _launchUrl(String url) async {
+    final uri = Uri.parse(url);
+    if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Could not open $url')),
+        );
+      }
+    }
+  }
+
+  // Shows the dialog for entering the ad-removal code.
+  void _showRemoveAdsDialog(BuildContext context) {
+    final themeProvider = Provider.of<ThemeProvider>(context, listen: false);
+
+    showDialog(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text("Remove Ads"),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // UPDATED: The text is now clearer about how to get the code.
+              const Text("Tap the button to visit our Facebook page. The secret code will then appear here in a message."),
+              const SizedBox(height: 24),
+              FilledButton.icon(
+                icon: const Icon(Icons.facebook),
+                label: const Text("Go to Facebook Page"),
+                onPressed: () {
+                  _launchUrl("https://www.facebook.com/profile.php?id=100095224335357");
+                  // NEW: Show a SnackBar (toast) with the code after the button is tapped.
+                  // We use the main `context` to ensure the SnackBar can find the Scaffold.
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text("Hint: The secret code is $_secretCode"),
+                      duration: Duration(seconds: 8), // Keep it on screen longer
+                      behavior: SnackBarBehavior.floating,
+                    ),
+                  );
+                },
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _codeController,
+                autofocus: true,
+                decoration: const InputDecoration(
+                  labelText: "Secret Code",
+                  hintText: "Enter code here",
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext),
+              child: const Text("Cancel"),
+            ),
+            TextButton(
+              onPressed: () {
+                if (_codeController.text.trim() == _secretCode) {
+                  // If the code is correct, update the provider and close the dialog.
+                  themeProvider.adsEnabled = false;
+                  Navigator.pop(dialogContext);
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text("Success! Ads have been disabled.")),
+                  );
+                } else {
+                  // If incorrect, show an error and clear the field.
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text("Incorrect code. Please try again."), backgroundColor: Colors.red),
+                  );
+                }
+                _codeController.clear();
+              },
+              child: const Text("Submit"),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
+    // We need to watch the provider to rebuild when adsEnabled changes.
+    final themeProvider = context.watch<ThemeProvider>();
+
     return SettingsPageTemplate(
       title: "Settings",
       children: [
@@ -25,39 +129,60 @@ class SettingsPage extends StatelessWidget {
         SettingsListItem(
           icon: Icons.palette_outlined,
           label: "Appearance",
-          onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const AppearanceSettingsPage()),
-          ),
+          onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const AppearanceSettingsPage())),
           isFirstItem: true,
         ),
         SettingsListItem(
           icon: Icons.system_update,
           label: "Updates",
-          onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const UpdatesPage()),
-          ),
+          onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const UpdatesPage())),
         ),
         SettingsListItem(
           icon: Icons.language_outlined,
           label: "Websites",
-          onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const WebsitesPage()),
-          ),
-          // UPDATED: isLastItem is now true
+          onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const WebsitesPage())),
           isLastItem: true,
         ),
+
+        // --- NEW: Support Group ---
+        const SettingsGroupTitle(title: "Support Us"),
+        // Conditionally show either the "Remove Ads" button or the "Ads Enabled" toggle.
+        if (themeProvider.adsEnabled)
+          SettingsListItem(
+            icon: Icons.favorite_border_rounded,
+            label: "Remove Ads",
+            subtitle: "Follow us to get a code and enjoy an ad-free experience.",
+            onTap: () => _showRemoveAdsDialog(context),
+            isFirstItem: true,
+            isLastItem: true,
+          )
+        else
+          SettingsListItem(
+            icon: Icons.favorite_rounded,
+            label: "Ads Enabled",
+            subtitle: "Thank you for your support!",
+            trailing: Switch(
+              value: themeProvider.adsEnabled,
+              onChanged: (value) {
+                themeProvider.adsEnabled = value;
+              },
+            ),
+            isFirstItem: true,
+            isLastItem: true,
+          ),
 
         // --- About Group ---
         const SettingsGroupTitle(title: "About"),
         SettingsListItem(
           icon: Icons.info_outline,
           label: "About App",
-          // UPDATED: onTap now navigates to the new AboutAppPage.
           onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const AboutAppPage())),
           isFirstItem: true,
         ),
         SettingsListItem(
           icon: Icons.privacy_tip_outlined,
           label: "Privacy Policy",
-          onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const PrivacyPolicyPage()),
-          ),
+          onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const PrivacyPolicyPage())),
           isLastItem: true,
         ),
       ],

--- a/lib/settings/websites_page.dart
+++ b/lib/settings/websites_page.dart
@@ -39,12 +39,12 @@ class WebsitesPage extends StatelessWidget {
         ),
         SettingsListItem(
           icon: Icons.developer_mode_rounded,
-          label: "HiDev",
-          onTap: () => _launchExternalUrl(context, 'https://sites.google.com/view/nuggetdev'),
+          label: "nuggetdev",
+          onTap: () => _launchExternalUrl(context, 'https://hienterprises.github.io/nuggetdev/home'),
         ),
         SettingsListItem(
           icon: Icons.dashboard_rounded,
-          label: "Harmony Website",
+          label: "Harmony",
           onTap: () => _launchExternalUrl(context, 'https://hienterprises.github.io/harmony/home'),
           isLastItem: true,
         ),

--- a/lib/widgets/daily_affirmation_card.dart
+++ b/lib/widgets/daily_affirmation_card.dart
@@ -74,7 +74,7 @@ class _DailyAffirmationCardState extends State<DailyAffirmationCard> {
 
     return Card(
       elevation: 0, // Flat card design
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(0.0)),
       color: colorScheme.secondaryContainer, // Uses secondary container color for differentiation
       child: Padding(
         padding: const EdgeInsets.all(20.0), // Consistent internal padding

--- a/lib/widgets/responsive_scaffold.dart
+++ b/lib/widgets/responsive_scaffold.dart
@@ -1,0 +1,204 @@
+// lib/widgets/responsive_scaffold.dart
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+// Import models, pages, and other widgets
+import '../models/app_destination.dart';
+import '../theme_provider.dart'; // Assumed path
+
+// Import your fragments (pages)
+import '../fragments/home.dart';
+import '../fragments/restaurant.dart';
+import '../fragments/rewards_page.dart';
+import '../fragments/hotel.dart';
+import '../fragments/roomkey.dart';
+
+import '../settings/settings_page.dart';
+import '../helpcenter/helpcenter_page.dart';
+
+// Import the custom AnimatedFabMenu widget
+import 'animated_fab_menu.dart'; // Make sure this path is correct
+
+// ResponsiveScaffold is the main UI scaffold that adapts navigation for wide or narrow screens
+class ResponsiveScaffold extends StatefulWidget {
+  final bool dynamicColorSupported; // Whether dynamic color is supported on this device
+
+  const ResponsiveScaffold({Key? key, required this.dynamicColorSupported})
+      : super(key: key);
+
+  @override
+  State<ResponsiveScaffold> createState() => _ResponsiveScaffoldState();
+}
+
+class _ResponsiveScaffoldState extends State<ResponsiveScaffold> {
+  int _selectedIndex = 0; // Tracks currently selected navigation index
+
+  // The master list of destinations, now including both icon variants.
+  late final List<AppDestination> _allDestinations;
+
+  @override
+  void initState() {
+    super.initState();
+    // Initialize the master list here with your updated destinations.
+    _allDestinations = [
+      AppDestination(id: 'dashboard', label: 'Home', icon: Icons.home_outlined, selectedIcon: Icons.home, page: NativeWelcomePage(onNavigateToTab: _onItemTapped)),
+      AppDestination(id: 'food', label: 'Food', icon: Icons.restaurant_outlined, selectedIcon: Icons.restaurant, page: const RestaurantPage()),
+      AppDestination(id: 'rewards', label: 'Rewards', icon: Icons.stars, selectedIcon: Icons.stars, page: const RewardsPage()),
+      AppDestination(id: 'hotel', label: 'Hotel', icon: Icons.hotel_outlined, selectedIcon: Icons.hotel, page: const HotelPage()),
+      AppDestination(id: 'room_key', label: 'Room Key', icon: Icons.key_outlined, selectedIcon: Icons.key, page: const RoomKeyPage()),
+    ];
+  }
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  // This function now guarantees the dashboard is always included.
+  List<AppDestination> _getVisibleDestinations(ThemeProvider themeProvider) {
+    // Start with the dashboard, which is always visible.
+    final List<AppDestination> visible = [_allDestinations.first];
+
+    // Filter the rest of the destinations based on user settings.
+    final otherVisible = _allDestinations.skip(1).where((dest) {
+      return themeProvider.visibleDestinations[dest.id] ?? true;
+    });
+
+    visible.addAll(otherVisible);
+    return visible;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isWideScreen = MediaQuery.of(context).size.width >= 600;
+    final themeProvider = Provider.of<ThemeProvider>(context);
+
+    // Dynamically build the list of destinations that should be visible.
+    final List<AppDestination> visibleDestinations = _getVisibleDestinations(themeProvider);
+
+    // If the currently selected index is out of bounds (because an item was hidden),
+    // reset to the first page.
+    if (_selectedIndex >= visibleDestinations.length) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          setState(() {
+            _selectedIndex = 0;
+          });
+        }
+      });
+    }
+
+    // Define the MiniFabItems with the updated outlined icons.
+    final List<MiniFabItem> menuFabItems = [
+      MiniFabItem(
+        icon: Icons.download_for_offline_outlined,
+        label: 'Download Menus',
+        onTap: () => _launchExternalUrl('https://www.dropbox.com/scl/fo/7gmlnnjcau1np91ee83ht/h?rlkey=ifj506k3aal7ko7tfecy8oqyq&dl=0'),
+      ),
+      MiniFabItem(
+        icon: Icons.settings_outlined,
+        label: 'Settings',
+        onTap: () => _navigateToPage(const SettingsPage()),
+      ),
+      MiniFabItem(
+        icon: Icons.help_outline_rounded,
+        label: 'Help',
+        onTap: () => _navigateToPage(const HelpcenterPage()),
+      ),
+      MiniFabItem(
+        icon: Icons.web_outlined,
+        label: 'Visit Blog',
+        onTap: () => _launchExternalUrl('https://hienterprises.blogspot.com'),
+      ),
+    ];
+
+    return Scaffold(
+      body: Row(
+        children: [
+          if (isWideScreen) _buildNavigationRail(isWideScreen, visibleDestinations),
+          Expanded(
+            child: visibleDestinations.isEmpty
+                ? const Center(child: Text("An error has occurred."))
+                : visibleDestinations[_selectedIndex].page,
+          ),
+        ],
+      ),
+      bottomNavigationBar: isWideScreen ? null : _buildNavigationBar(themeProvider.useMaterial3, visibleDestinations),
+      floatingActionButton: AnimatedFabMenu(fabItems: menuFabItems),
+      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+    );
+  }
+
+  // Helper for launching URLs
+  Future<void> _launchExternalUrl(String url) async {
+    final uri = Uri.parse(url);
+    if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Could not launch $url')),
+        );
+      }
+    }
+  }
+
+  // Helper for navigation
+  void _navigateToPage(Widget page) {
+    if (mounted) {
+      Navigator.push(context, MaterialPageRoute(builder: (_) => page));
+    }
+  }
+
+  // UPDATED: Now uses the `selectedIcon` property for a cleaner implementation.
+  NavigationRail _buildNavigationRail(bool isWideScreen, List<AppDestination> destinations) {
+    return NavigationRail(
+      selectedIndex: _selectedIndex,
+      onDestinationSelected: _onItemTapped,
+      labelType: isWideScreen
+          ? NavigationRailLabelType.all
+          : NavigationRailLabelType.none,
+      destinations: destinations.map((dest) {
+        return NavigationRailDestination(
+          icon: Icon(dest.icon),
+          selectedIcon: Icon(dest.selectedIcon), // Use the filled icon for the selected state
+          label: Text(dest.label),
+        );
+      }).toList(),
+    );
+  }
+
+  // UPDATED: Now uses the `selectedIcon` property for M3 and dynamic icons for M2.
+  Widget _buildNavigationBar(bool useMaterial3, List<AppDestination> destinations) {
+    if (useMaterial3) {
+      return NavigationBar(
+        selectedIndex: _selectedIndex,
+        onDestinationSelected: _onItemTapped,
+        destinations: destinations.map((dest) {
+          return NavigationDestination(
+            icon: Icon(dest.icon),
+            selectedIcon: Icon(dest.selectedIcon), // Use the filled icon for the selected state
+            label: dest.label,
+          );
+        }).toList(),
+      );
+    } else {
+      // Material 2 style BottomNavigationBar
+      return BottomNavigationBar(
+        currentIndex: _selectedIndex,
+        onTap: _onItemTapped,
+        type: BottomNavigationBarType.fixed,
+        // Dynamically build the items, choosing the correct icon based on the selected index.
+        items: destinations.asMap().entries.map((entry) {
+          final int index = entry.key;
+          final AppDestination dest = entry.value;
+          return BottomNavigationBarItem(
+            icon: Icon(_selectedIndex == index ? dest.selectedIcon : dest.icon),
+            label: dest.label,
+          );
+        }).toList(),
+      );
+    }
+  }
+}

--- a/lib/widgets/video_ad_dialog.dart
+++ b/lib/widgets/video_ad_dialog.dart
@@ -1,0 +1,141 @@
+import 'dart:async';
+import 'dart:math'; // Import the math library for the random number generator
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+/// A dialog that shows a random YouTube video ad and forces a wait time before skipping.
+class VideoAdDialog extends StatefulWidget {
+  // The action to perform after the user skips the ad.
+  final VoidCallback onSkipped;
+
+  const VideoAdDialog({super.key, required this.onSkipped});
+
+  @override
+  State<VideoAdDialog> createState() => _VideoAdDialogState();
+}
+
+class _VideoAdDialogState extends State<VideoAdDialog> {
+  // The list of YouTube video IDs to choose from.
+  static final List<String> _videoIds = const [
+    '7By-gcfB_iY', // Welcome to WorstEastern
+    'cr_hByEBpFg', // MyLad 2.0E
+    'mL6l87z3E7g', // MyPhone
+    '3YNGaQyFSRE', // MyTV
+    'e0L0zvhrlM8', // MyLad 2.0D
+    'o50a0E7ibBg', // MyLap
+  ];
+
+  // Helper to create the standard YouTube embed URL.
+  String _getEmbedUrl(String videoId) {
+    // Parameters to hide controls, related videos, etc., and enable autoplay.
+    return 'https://www.youtube.com/embed/$videoId?autoplay=1&controls=0&showinfo=0&rel=0&iv_load_policy=3&modestbranding=1';
+  }
+
+  late String _videoAdUrl; // Will hold the randomly selected video URL
+  late Timer _timer;
+  int _secondsRemaining = 15;
+  bool _canSkip = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectRandomVideo();
+    _startCountdown();
+  }
+
+  // New method to pick a random video from the list.
+  void _selectRandomVideo() {
+    final random = Random();
+    final randomIndex = random.nextInt(_videoIds.length);
+    final randomVideoId = _videoIds[randomIndex];
+    _videoAdUrl = _getEmbedUrl(randomVideoId);
+  }
+
+  void _startCountdown() {
+    // Start a periodic timer that fires every second.
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (_secondsRemaining > 0) {
+        if (mounted) {
+          setState(() {
+            _secondsRemaining--;
+          });
+        }
+      } else {
+        // When the countdown finishes, enable the skip button and stop the timer.
+        if (mounted) {
+          setState(() {
+            _canSkip = true;
+          });
+        }
+        timer.cancel();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel(); // Always cancel timers in dispose to prevent memory leaks.
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    // Use WillPopScope to prevent the user from closing the dialog with the back button.
+    return WillPopScope(
+      onWillPop: () async => false, // Prevents back-button dismissal
+      child: Dialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        child: Container(
+          width: 600, // Constrain the width for a dialog-like appearance
+          height: 450, // Constrain the height
+          color: Colors.black,
+          child: Column(
+            children: [
+              // The WebView takes up most of the space.
+              Expanded(
+                child: InAppWebView(
+                  initialUrlRequest: URLRequest(url: WebUri(_videoAdUrl)),
+                  initialSettings: InAppWebViewSettings(
+                    // These settings are crucial for web autoplay to work.
+                    mediaPlaybackRequiresUserGesture: false,
+                    allowsInlineMediaPlayback: true,
+                    iframeAllowFullscreen: true,
+                  ),
+                ),
+              ),
+              // The skip button and countdown timer section.
+              Padding(
+                padding: const EdgeInsets.all(12.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    // The skip button is only visible when _canSkip is true.
+                    if (_canSkip)
+                      ElevatedButton(
+                        onPressed: () {
+                          // Close the dialog first.
+                          Navigator.of(context).pop();
+                          // Then, execute the original action.
+                          widget.onSkipped();
+                        },
+                        child: const Text("Skip Ad"),
+                      )
+                    else
+                    // Otherwise, show the countdown timer.
+                      Text(
+                        "You can skip in $_secondsRemaining seconds...",
+                        style: theme.textTheme.bodyMedium
+                            ?.copyWith(color: Colors.white70),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 3.4.0+10
+version: 3.4.1+11
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
This commit introduces a monetization feature through video ads and refactors the main application structure for better organization.

**Feature: Video Ads**
-   A new `VideoAdDialog` has been created to display a random, skippable ad after a 15-second countdown.
-   The dialog is triggered with a 25% chance when a user navigates to a restaurant detail page.
-   An option to disable ads has been added in the Settings page. Users can get a secret code by visiting the app's Facebook page.
-   A `ThemeProvider` setting (`adsEnabled`) was added to manage and persist the user's ad preference.

**Refactor: App Structure**
-   The main application logic in `main.dart` has been split into smaller, more focused widgets:
    -   `app.dart` (`Harmony` widget): Now handles `MaterialApp` theme and configuration.
    -   `widgets/responsive_scaffold.dart`: Contains the main scaffold logic, including the navigation rail/bar and FAB menu.
    -   `models/app_destination.dart`: A new model file for the `AppDestination` class.
-   This refactoring improves code organization and maintainability without changing UI/UX.

**Other Changes:**
-   **Settings:**
    -   The "Support Us" section now dynamically shows either the "Remove Ads" button or an "Ads Enabled" toggle based on the user's preference.
    -   Website links have been updated.
-   **UI:** The `DailyAffirmationCard` now has `0.0` corner radius to fit flush within its container.
-   **Version:** Incremented app version to `3.4.1+11`.